### PR TITLE
Update stepfunction.json to reference initialSummary for summarization

### DIFF
--- a/infrastructure/stepfunction.json
+++ b/infrastructure/stepfunction.json
@@ -13,7 +13,7 @@
         "videoKeys.$": "$.videoKeys",
         "context": {
           "transcription.$": "$.initialPrompt",
-          "summarization": ""
+          "summarization.$": "$.initialSummary"
         }
       }
     },


### PR DESCRIPTION
This pull request includes a change to the `infrastructure/stepfunction.json` file to update the way summarization data is referenced in the context object.

* [`infrastructure/stepfunction.json`](diffhunk://#diff-bb965c06e0cae0afb20194992a43dbe8ee939477f983227e43bb2314c558522dL16-R16): Changed the `summarization` field to reference `$.initialSummary` instead of an empty string.