### PR TITLE
feat: add start time tracking and save to DynamoDB in stream ingestion process

### DIFF
--- a/cdk/lib/streamIngestion.ts
+++ b/cdk/lib/streamIngestion.ts
@@ -339,7 +339,7 @@ The summary you generate must be not only informational for content review but a
       parameters: {
         'index.$': 'States.MathAdd(1, $.iterator.index)',
         'start_time.$':
-          'States.MathAdd($.iterator.start_time, $.dynamodb.Item.metadata.M.format.M.duration.N)',
+          'States.MathAdd($.iterator.start_time, States.StringToJson($.dynamodb.Item.metadata.M.format.M.duration.N))',
       },
       resultPath: '$.iterator',
     });

--- a/cdk/lib/streamIngestion.ts
+++ b/cdk/lib/streamIngestion.ts
@@ -338,7 +338,7 @@ The summary you generate must be not only informational for content review but a
       comment: 'Increment the iterator index',
       parameters: {
         'index.$': 'States.MathAdd(1, $.iterator.index)',
-        start_time:
+        'start_time.$':
           'States.MathAdd($.iterator.start_time, $.dynamodb.Item.metadata.M.format.M.duration.N)',
       },
       resultPath: '$.iterator',


### PR DESCRIPTION

This pull request makes several changes to the `cdk/lib/streamIngestion.ts` file to enhance the handling of the `start_time` attribute in the stream ingestion process. The main changes involve initializing, updating, and saving the `start_time` in DynamoDB.

Key changes include:

*Initialization and Update of `start_time`:*

* Modified the initial state to include `start_time` in the iterator.
* Added logic to increment the `start_time` based on the metadata duration in the iterator.

*DynamoDB Integration:*

* Introduced a new task to save the `start_time` to DynamoDB.
* Updated the state machine to include the new task for saving `start_time` after retrieving an item from DynamoDB.
* Added a projection expression to extract metadata for the duration to increment the `start_time`.