### PR TITLE
fix: update YouTube uploader to correctly access nested properties in upload result

### DIFF
--- a/cdk/lib/youtubeUploader.ts
+++ b/cdk/lib/youtubeUploader.ts
@@ -174,7 +174,7 @@ export default class YoutubeUploader extends Construct {
               value: {
                 episodeId: cdk.aws_stepfunctions.JsonPath.stringAt('$.id'),
                 errorMessage: cdk.aws_stepfunctions.JsonPath.stringAt(
-                  '$.uploadVideoResult.error_message',
+                  '$.uploadVideoResult.Item.error_message.S',
                 ),
               },
             },
@@ -261,20 +261,20 @@ export default class YoutubeUploader extends Construct {
         new sfn.Choice(this, 'UploadSuccess?')
           .when(
             sfn.Condition.stringEquals(
-              '$.uploadVideoResult.upload_status',
+              '$.uploadVideoResult.Item.upload_status.S',
               UPLOAD_FAILED,
             ),
             markAsNotReadyToUploadState.next(notifyFailureState),
           )
           .when(
             sfn.Condition.stringEquals(
-              '$.uploadVideoResult.upload_status',
+              '$.uploadVideoResult.Item.upload_status.S',
               UPLOAD_THROTTLED,
             ),
             new sfn.Wait(this, 'WaitForRetry', {
               comment: 'Wait for the amount of time specified in the response',
               time: sfn.WaitTime.secondsPath(
-                '$.uploadVideoResult.retry_after_seconds',
+                '$.uploadVideoResult.Item.retry_after_seconds.N',
               ),
             }).next(uploadVideoState),
           )


### PR DESCRIPTION
This pull request includes changes to the `YoutubeUploader` class in the `cdk/lib/youtubeUploader.ts` file to update the JSON path for accessing specific properties in the `uploadVideoResult` object.

Key changes include:

* Updated the JSON path for `error_message` to `$.uploadVideoResult.Item.error_message.S`
* Updated the JSON path for `upload_status` to `$.uploadVideoResult.Item.upload_status.S` in two instances
* Updated the JSON path for `retry_after_seconds` to `$.uploadVideoResult.Item.retry_after_seconds.N`