### PR TITLE
feat: enable point-in-time recovery for DynamoDB tables

### DIFF
--- a/cdk/lib/datastore.ts
+++ b/cdk/lib/datastore.ts
@@ -121,6 +121,9 @@ export default class DatastoreConstruct extends Construct {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
     });
 
     episodesTable.addGlobalSecondaryIndex({
@@ -142,24 +145,36 @@ export default class DatastoreConstruct extends Construct {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
     });
 
     this.streamSeriesTable = new dynamodb.Table(this, 'StreamSeriesTable', {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
     });
 
     this.streamsTable = new dynamodb.Table(this, 'StreamsTable', {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
     });
 
     const videoMetadataTable = new dynamodb.Table(this, 'VideoMetadataTable', {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       partitionKey: { name: 'key', type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
     });
 
     videoMetadataTable.addGlobalSecondaryIndex({
@@ -179,12 +194,16 @@ export default class DatastoreConstruct extends Construct {
       timeToLiveAttribute: 'ttl',
       removalPolicy: cdk.RemovalPolicy.RETAIN,
       stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
+      // no backups for ephemeral tasks table
     });
 
     this.projectsTable = new dynamodb.Table(this, 'ProjectsTable', {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
     });
 
     const chatMessagesTable = new dynamodb.Table(this, 'ChatMessagesTable', {
@@ -193,6 +212,9 @@ export default class DatastoreConstruct extends Construct {
       sortKey: { name: 'timestamp', type: dynamodb.AttributeType.STRING },
       timeToLiveAttribute: 'ttl',
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
     });
 
     // Add GSI for querying by channel_id
@@ -217,6 +239,9 @@ export default class DatastoreConstruct extends Construct {
       partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.RETAIN,
       stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
     });
 
     // Add GSI for user_id (primary query pattern: get all widgets for a user)


### PR DESCRIPTION
This pull request updates the DynamoDB table definitions in the `DatastoreConstruct` class to enable point-in-time recovery (PITR) for most tables. PITR provides automatic continuous backups, allowing recovery to any point within the last 35 days. This change enhances data durability and disaster recovery capabilities for the application's data stores.

**Enhancements to DynamoDB table resilience:**

* Enabled `pointInTimeRecoverySpecification` with `pointInTimeRecoveryEnabled: true` for the following tables to provide continuous backups:
  - `EpisodesTable`
  - `StreamSeriesTable`
  - `StreamsTable`
  - `VideoMetadataTable`
  - `ProjectsTable`
  - `ChatMessagesTable`
  - `WidgetsTable` [[1]](diffhunk://#diff-103444e27329bca193ad44de407b8b1e6aed12a8916cc60170d511b91bc01e5bR124-R126) [[2]](diffhunk://#diff-103444e27329bca193ad44de407b8b1e6aed12a8916cc60170d511b91bc01e5bR148-R177) [[3]](diffhunk://#diff-103444e27329bca193ad44de407b8b1e6aed12a8916cc60170d511b91bc01e5bR197-R206) [[4]](diffhunk://#diff-103444e27329bca193ad44de407b8b1e6aed12a8916cc60170d511b91bc01e5bR215-R217) [[5]](diffhunk://#diff-103444e27329bca193ad44de407b8b1e6aed12a8916cc60170d511b91bc01e5bR242-R244)

**Note:** PITR was intentionally not enabled for the `TasksTable`, as indicated by the comment, since this table is meant for temporary data.