### PR TITLE
Integrate Twitch API for ad scheduling and enhance widget support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4948,9 +4948,12 @@ version = "0.1.0"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
+ "aws-sdk-secretsmanager",
  "chrono",
  "gt_app",
+ "gt_secrets",
  "lambda_runtime",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tokio",

--- a/cdk/lib/api.ts
+++ b/cdk/lib/api.ts
@@ -54,6 +54,7 @@ interface APIConstructProps {
 
 export default class APIConstruct extends Construct {
   public readonly httpApi: apigwv2.HttpApi;
+  public readonly twitchAppSecret: secretsmanager.ISecret;
 
   constructor(scope: Construct, id: string, props: APIConstructProps) {
     super(scope, id);
@@ -154,6 +155,7 @@ export default class APIConstruct extends Construct {
       description: 'Twitch App Secret for API access in glowing-telegram',
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
+    this.twitchAppSecret = twitchAppSecret;
 
     // EventSub webhook secret for signature verification
     const eventSubSecret = new secretsmanager.Secret(this, 'EventSubSecret', {

--- a/cdk/lib/appStack.ts
+++ b/cdk/lib/appStack.ts
@@ -172,12 +172,6 @@ export default class AppStack extends cdk.Stack {
       tagOrDigest,
     });
 
-    // Widget updater for scheduled background updates (e.g., countdown timers)
-    new WidgetUpdaterConstruct(this, 'WidgetUpdater', {
-      streamWidgetsTable: dataStore.streamWidgetsTable,
-      tagOrDigest,
-    });
-
     const twitchChatProcessing = new TwitchChatProcessingConstruct(this, 'TwitchChatProcessing', {
       chatMessagesTable: dataStore.chatMessagesTable,
       tagOrDigest,
@@ -213,6 +207,14 @@ export default class AppStack extends cdk.Stack {
       videoArchiveBucket: dataStore.videoArchive,
 
       domainName,
+      tagOrDigest,
+    });
+
+    // Widget updater for scheduled background updates (e.g., countdown timers, ad_timer)
+    new WidgetUpdaterConstruct(this, 'WidgetUpdater', {
+      streamWidgetsTable: dataStore.streamWidgetsTable,
+      twitchAppSecret: api.twitchAppSecret,
+      twitchUserSecretBasePath: TWITCH_USER_SECRET_BASE_PATH,
       tagOrDigest,
     });
 

--- a/cdk/lib/appStack.ts
+++ b/cdk/lib/appStack.ts
@@ -174,6 +174,7 @@ export default class AppStack extends cdk.Stack {
 
     const twitchChatProcessing = new TwitchChatProcessingConstruct(this, 'TwitchChatProcessing', {
       chatMessagesTable: dataStore.chatMessagesTable,
+      streamWidgetsTable: dataStore.streamWidgetsTable,
       tagOrDigest,
     });
 

--- a/cdk/lib/twitchChatProcessing.ts
+++ b/cdk/lib/twitchChatProcessing.ts
@@ -9,6 +9,7 @@ import ServiceLambdaConstruct from './util/serviceLambda';
 
 interface TwitchChatProcessingProps {
   chatMessagesTable: dynamodb.ITable;
+  streamWidgetsTable: dynamodb.ITable;
   tagOrDigest?: string;
 }
 
@@ -43,6 +44,7 @@ export default class TwitchChatProcessingConstruct extends Construct {
           environment: {
             CHAT_MESSAGES_TABLE: props.chatMessagesTable.tableName,
             CHAT_MESSAGE_TTL_DAYS: '365', // Set TTL for chat messages
+            STREAM_WIDGETS_TABLE: props.streamWidgetsTable.tableName,
           },
         },
         name: 'chat-processor-lambda',
@@ -63,7 +65,7 @@ export default class TwitchChatProcessingConstruct extends Construct {
     // Grant Lambda permissions to read from SQS
     this.chatQueue.grantConsumeMessages(this.processingLambda);
 
-    // Grant Lambda permissions to write to DynamoDB
+    // Grant Lambda permissions to write chat messages to DynamoDB
     this.processingLambda.addToRolePolicy(
       new iam.PolicyStatement({
         actions: [
@@ -72,6 +74,21 @@ export default class TwitchChatProcessingConstruct extends Construct {
           'dynamodb:GetItem',
         ],
         resources: [props.chatMessagesTable.tableArn],
+      }),
+    );
+
+    // Grant Lambda permissions to read and update stream widgets in DynamoDB
+    this.processingLambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: [
+          'dynamodb:Scan',
+          'dynamodb:UpdateItem',
+          'dynamodb:GetItem',
+        ],
+        resources: [
+          props.streamWidgetsTable.tableArn,
+          `${props.streamWidgetsTable.tableArn}/index/*`,
+        ],
       }),
     );
   }

--- a/cdk/lib/widgetUpdater.ts
+++ b/cdk/lib/widgetUpdater.ts
@@ -6,10 +6,15 @@ import * as targets from 'aws-cdk-lib/aws-events-targets';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import ServiceLambdaConstruct from './util/serviceLambda';
 
 export interface WidgetUpdaterConstructProps {
   streamWidgetsTable: dynamodb.ITable;
+  /** The Twitch app secret (contains client_id / client_secret). */
+  twitchAppSecret: secretsmanager.ISecret;
+  /** Base path for per-user Twitch secrets, e.g. "gt/twitch/user". */
+  twitchUserSecretBasePath: string;
   tagOrDigest?: string;
 }
 
@@ -21,10 +26,12 @@ export default class WidgetUpdaterConstruct extends Construct {
       name: 'widget-updater-lambda',
       tagOrDigest: props.tagOrDigest,
       lambdaOptions: {
-        timeout: cdk.Duration.seconds(1),
+        timeout: cdk.Duration.seconds(30),
         memorySize: 256,
         environment: {
           STREAM_WIDGETS_TABLE: props.streamWidgetsTable.tableName,
+          TWITCH_SECRET_ARN: props.twitchAppSecret.secretArn,
+          USER_SECRET_PATH: props.twitchUserSecretBasePath,
         },
         description: 'Processes scheduled updates for stream widgets',
       },
@@ -33,7 +40,28 @@ export default class WidgetUpdaterConstruct extends Construct {
     // Grant read/write access to stream_widgets table
     props.streamWidgetsTable.grantReadWriteData(service.lambda);
 
-    // Create EventBridge rule for countdown widgets (every 1 second)
+    // Grant read access to the Twitch app secret (for client_id at cold-start)
+    props.twitchAppSecret.grantRead(service.lambda);
+
+    // Grant read access to per-user Twitch secrets (for access tokens)
+    service.lambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['secretsmanager:GetSecretValue'],
+        resources: [
+          cdk.Arn.format(
+            {
+              service: 'secretsmanager',
+              resource: 'secret',
+              resourceName: `${props.twitchUserSecretBasePath}/*`,
+              arnFormat: cdk.ArnFormat.COLON_RESOURCE_NAME,
+            },
+            cdk.Stack.of(this),
+          ),
+        ],
+      }),
+    );
+
+    // Create EventBridge rule for countdown widgets (every 1 minute)
     const countdownRule = new events.Rule(this, 'CountdownWidgetUpdateRule', {
       schedule: events.Schedule.rate(cdk.Duration.minutes(1)),
       description: 'Triggers widget updater for countdown widgets',
@@ -47,19 +75,20 @@ export default class WidgetUpdaterConstruct extends Construct {
       }),
     );
 
-    // Future widget types can be added here with different schedules
-    // Example: Poll widgets every 5 minutes
-    // const pollRule = new events.Rule(this, 'PollWidgetUpdateRule', {
-    //   schedule: events.Schedule.rate(cdk.Duration.minutes(5)),
-    //   description: 'Triggers widget updater for poll widgets',
-    // });
-    //
-    // pollRule.addTarget(
-    //   new targets.LambdaFunction(this.widgetUpdaterFunction, {
-    //     event: events.RuleTargetInput.fromObject({
-    //       widget_type: 'poll',
-    //     }),
-    //   }),
-    // );
+    // Create EventBridge rule for ad_timer widgets (every 5 minutes).
+    // The backend polls the Twitch ad schedule API and pushes state via WebSocket.
+    // See src/widgets/ad-timer/BACKEND_INTEGRATION.md in glowing-telegram-frontend.
+    const adTimerRule = new events.Rule(this, 'AdTimerWidgetUpdateRule', {
+      schedule: events.Schedule.rate(cdk.Duration.minutes(5)),
+      description: 'Triggers widget updater for ad_timer widgets (Twitch ad schedule polling)',
+    });
+
+    adTimerRule.addTarget(
+      new targets.LambdaFunction(service.lambda, {
+        event: events.RuleTargetInput.fromObject({
+          widget_type: 'ad_timer',
+        }),
+      }),
+    );
   }
 }

--- a/chat_processor_lambda/src/main.rs
+++ b/chat_processor_lambda/src/main.rs
@@ -218,33 +218,53 @@ async fn process_ad_break_begin(
                     .to_rfc3339()
             });
 
-    // Query all active ad_timer widgets for this broadcaster.
-    // The broadcaster_user_id from Twitch is stored in the widget's user_id field.
-    // Note: This uses a Scan with a filter, which is acceptable given the
-    // expected low cardinality of active ad_timer widgets.
-    let scan_result = context
-        .dynamodb
-        .scan()
-        .table_name(&context.config.stream_widgets_table)
-        .filter_expression(
-            "#type = :widget_type AND #active = :active AND #user_id = :broadcaster_id",
-        )
-        .expression_attribute_names("#type", "type")
-        .expression_attribute_names("#active", "active")
-        .expression_attribute_names("#user_id", "user_id")
-        .expression_attribute_values(
-            ":widget_type",
-            AttributeValue::S("ad_timer".to_string()),
-        )
-        .expression_attribute_values(":active", AttributeValue::Bool(true))
-        .expression_attribute_values(
-            ":broadcaster_id",
-            AttributeValue::S(event.broadcaster_user_id.clone()),
-        )
-        .send()
-        .await?;
+    // Query the user_id-index GSI to efficiently find active ad_timer widgets
+    // for this broadcaster, and paginate through all results.
+    let mut items: Vec<HashMap<String, AttributeValue>> = Vec::new();
+    let mut exclusive_start_key: Option<HashMap<String, AttributeValue>> = None;
 
-    let items = scan_result.items.unwrap_or_default();
+    loop {
+        let mut query_builder = context
+            .dynamodb
+            .query()
+            .table_name(&context.config.stream_widgets_table)
+            .index_name("user_id-index")
+            .key_condition_expression("#user_id = :broadcaster_id")
+            .filter_expression("#type = :widget_type AND #active = :active")
+            .expression_attribute_names("#user_id", "user_id")
+            .expression_attribute_names("#type", "type")
+            .expression_attribute_names("#active", "active")
+            .expression_attribute_values(
+                ":broadcaster_id",
+                AttributeValue::S(event.broadcaster_user_id.clone()),
+            )
+            .expression_attribute_values(
+                ":widget_type",
+                AttributeValue::S("ad_timer".to_string()),
+            )
+            .expression_attribute_values(
+                ":active",
+                AttributeValue::Bool(true),
+            );
+
+        if let Some(start_key) = exclusive_start_key.take() {
+            query_builder =
+                query_builder.set_exclusive_start_key(Some(start_key));
+        }
+
+        let query_result = query_builder.send().await?;
+
+        if let Some(mut page_items) = query_result.items {
+            items.append(&mut page_items);
+        }
+
+        match query_result.last_evaluated_key {
+            Some(key) if !key.is_empty() => {
+                exclusive_start_key = Some(key);
+            }
+            _ => break,
+        }
+    }
     info!(
         "Found {} active ad_timer widgets for broadcaster {}",
         items.len(),
@@ -258,38 +278,48 @@ async fn process_ad_break_begin(
             continue;
         };
 
-        // Build the new state as a DynamoDB map.
-        // nextAdAt is cleared (null) since we are now in the break.
+        // Update only the relevant nested fields within the existing state map.
+        // nextAdAt is cleared since we are now in the break.
         // backFromAdsUntil marks when the break ends.
-        let mut new_state: HashMap<String, AttributeValue> = HashMap::new();
-        new_state.insert("nextAdAt".to_string(), AttributeValue::Null(true));
-        if let Some(ref until) = back_from_ads_until {
-            new_state.insert(
-                "backFromAdsUntil".to_string(),
-                AttributeValue::S(until.clone()),
-            );
-        }
-
-        let result = context
+        // This preserves any other state fields (e.g. snoozeCount, snoozedAt).
+        let base_update = context
             .dynamodb
             .update_item()
             .table_name(&context.config.stream_widgets_table)
             .key("id", AttributeValue::S(widget_id.clone()))
-            .update_expression(
-                "SET #state = :new_state, #updated_at = :updated_at",
-            )
             .expression_attribute_names("#state", "state")
+            .expression_attribute_names("#nextAdAt", "nextAdAt")
+            .expression_attribute_names("#backFromAdsUntil", "backFromAdsUntil")
             .expression_attribute_names("#updated_at", "updated_at")
             .expression_attribute_values(
-                ":new_state",
-                AttributeValue::M(new_state),
+                ":next_ad_at",
+                AttributeValue::Null(true),
             )
             .expression_attribute_values(
                 ":updated_at",
                 AttributeValue::S(now.clone()),
+            );
+
+        let update = if let Some(ref until) = back_from_ads_until {
+            base_update
+                .update_expression(
+                    "SET #state.#nextAdAt = :next_ad_at, \
+                     #state.#backFromAdsUntil = :back_from_ads_until, \
+                     #updated_at = :updated_at",
+                )
+                .expression_attribute_values(
+                    ":back_from_ads_until",
+                    AttributeValue::S(until.clone()),
+                )
+        } else {
+            base_update.update_expression(
+                "SET #state.#nextAdAt = :next_ad_at, \
+                 #updated_at = :updated_at \
+                 REMOVE #state.#backFromAdsUntil",
             )
-            .send()
-            .await;
+        };
+
+        let result = update.send().await;
 
         match result {
             Ok(_) => {

--- a/chat_processor_lambda/src/main.rs
+++ b/chat_processor_lambda/src/main.rs
@@ -210,14 +210,13 @@ async fn process_ad_break_begin(
     );
 
     // Compute when the ad break ends so the frontend can derive status correctly.
-    let back_from_ads_until = chrono::DateTime::parse_from_rfc3339(
-        &event.started_at,
-    )
-    .ok()
-    .map(|t| {
-        (t + chrono::Duration::seconds(event.duration_seconds))
-            .to_rfc3339()
-    });
+    let back_from_ads_until =
+        chrono::DateTime::parse_from_rfc3339(&event.started_at)
+            .ok()
+            .map(|t| {
+                (t + chrono::Duration::seconds(event.duration_seconds))
+                    .to_rfc3339()
+            });
 
     // Query all active ad_timer widgets for this broadcaster.
     // The broadcaster_user_id from Twitch is stored in the widget's user_id field.
@@ -263,10 +262,7 @@ async fn process_ad_break_begin(
         // nextAdAt is cleared (null) since we are now in the break.
         // backFromAdsUntil marks when the break ends.
         let mut new_state: HashMap<String, AttributeValue> = HashMap::new();
-        new_state.insert(
-            "nextAdAt".to_string(),
-            AttributeValue::Null(true),
-        );
+        new_state.insert("nextAdAt".to_string(), AttributeValue::Null(true));
         if let Some(ref until) = back_from_ads_until {
             new_state.insert(
                 "backFromAdsUntil".to_string(),
@@ -296,7 +292,9 @@ async fn process_ad_break_begin(
             .await;
 
         match result {
-            Ok(_) => info!("Updated ad_timer widget {} to in_ad_break", widget_id),
+            Ok(_) => {
+                info!("Updated ad_timer widget {} to in_ad_break", widget_id)
+            }
             Err(e) => error!("Failed to update widget {}: {:?}", widget_id, e),
         }
     }

--- a/chat_processor_lambda/src/main.rs
+++ b/chat_processor_lambda/src/main.rs
@@ -12,6 +12,7 @@ use tracing::{error, info};
 struct Config {
     chat_messages_table: String,
     chat_message_ttl_days: i64,
+    stream_widgets_table: String,
 }
 
 #[derive(Debug, Clone)]
@@ -48,10 +49,21 @@ struct TwitchChatMessage {
     text: String,
 }
 
+/// Payload for channel.ad_break.begin EventSub events.
+#[derive(Debug, Deserialize)]
+struct TwitchAdBreakEvent {
+    /// Twitch broadcaster user ID (not Cognito user ID).
+    broadcaster_user_id: String,
+    /// Duration of the ad break in seconds.
+    duration_seconds: i64,
+    /// ISO 8601 timestamp when the ad break started.
+    started_at: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct EventSubMessage {
     subscription: EventSubSubscription,
-    event: TwitchChatEvent,
+    event: serde_json::Value,
 }
 
 #[derive(Debug, Deserialize)]
@@ -99,15 +111,28 @@ async fn process_message(
     // Parse the EventSub message
     let eventsub_message: EventSubMessage = serde_json::from_str(body)?;
 
-    if eventsub_message.subscription.event_type != "channel.chat.message" {
-        info!(
-            "Ignoring non-chat message event: {}",
-            eventsub_message.subscription.event_type
-        );
-        return Ok(());
+    match eventsub_message.subscription.event_type.as_str() {
+        "channel.chat.message" => {
+            let event: TwitchChatEvent =
+                serde_json::from_value(eventsub_message.event)?;
+            process_chat_message(event, context).await
+        }
+        "channel.ad_break.begin" => {
+            let event: TwitchAdBreakEvent =
+                serde_json::from_value(eventsub_message.event)?;
+            process_ad_break_begin(event, context).await
+        }
+        other => {
+            info!("Ignoring unhandled EventSub event type: {}", other);
+            Ok(())
+        }
     }
+}
 
-    let event = eventsub_message.event;
+async fn process_chat_message(
+    event: TwitchChatEvent,
+    context: &AppContext,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let chatter_name = event.chatter_user_name.clone();
 
     // Create a chat message record for DynamoDB
@@ -166,6 +191,115 @@ async fn process_message(
         .await?;
 
     info!("Successfully stored chat message from {}", chatter_name);
+
+    Ok(())
+}
+
+/// Handle a channel.ad_break.begin EventSub event.
+///
+/// Finds all active ad_timer widgets for this broadcaster and sets their state
+/// to in_ad_break so OBS sees the update immediately via DynamoDB Streams →
+/// WebSocket push, without waiting for the next polling cycle.
+async fn process_ad_break_begin(
+    event: TwitchAdBreakEvent,
+    context: &AppContext,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    info!(
+        "Ad break began for broadcaster {} — {} seconds, started at {}",
+        event.broadcaster_user_id, event.duration_seconds, event.started_at
+    );
+
+    // Compute when the ad break ends so the frontend can derive status correctly.
+    let back_from_ads_until = chrono::DateTime::parse_from_rfc3339(
+        &event.started_at,
+    )
+    .ok()
+    .map(|t| {
+        (t + chrono::Duration::seconds(event.duration_seconds))
+            .to_rfc3339()
+    });
+
+    // Query all active ad_timer widgets for this broadcaster.
+    // The broadcaster_user_id from Twitch is stored in the widget's user_id field.
+    // Note: This uses a Scan with a filter, which is acceptable given the
+    // expected low cardinality of active ad_timer widgets.
+    let scan_result = context
+        .dynamodb
+        .scan()
+        .table_name(&context.config.stream_widgets_table)
+        .filter_expression(
+            "#type = :widget_type AND #active = :active AND #user_id = :broadcaster_id",
+        )
+        .expression_attribute_names("#type", "type")
+        .expression_attribute_names("#active", "active")
+        .expression_attribute_names("#user_id", "user_id")
+        .expression_attribute_values(
+            ":widget_type",
+            AttributeValue::S("ad_timer".to_string()),
+        )
+        .expression_attribute_values(":active", AttributeValue::Bool(true))
+        .expression_attribute_values(
+            ":broadcaster_id",
+            AttributeValue::S(event.broadcaster_user_id.clone()),
+        )
+        .send()
+        .await?;
+
+    let items = scan_result.items.unwrap_or_default();
+    info!(
+        "Found {} active ad_timer widgets for broadcaster {}",
+        items.len(),
+        event.broadcaster_user_id
+    );
+
+    let now = Utc::now().to_rfc3339();
+
+    for item in &items {
+        let Some(AttributeValue::S(widget_id)) = item.get("id") else {
+            continue;
+        };
+
+        // Build the new state as a DynamoDB map.
+        // nextAdAt is cleared (null) since we are now in the break.
+        // backFromAdsUntil marks when the break ends.
+        let mut new_state: HashMap<String, AttributeValue> = HashMap::new();
+        new_state.insert(
+            "nextAdAt".to_string(),
+            AttributeValue::Null(true),
+        );
+        if let Some(ref until) = back_from_ads_until {
+            new_state.insert(
+                "backFromAdsUntil".to_string(),
+                AttributeValue::S(until.clone()),
+            );
+        }
+
+        let result = context
+            .dynamodb
+            .update_item()
+            .table_name(&context.config.stream_widgets_table)
+            .key("id", AttributeValue::S(widget_id.clone()))
+            .update_expression(
+                "SET #state = :new_state, #updated_at = :updated_at",
+            )
+            .expression_attribute_names("#state", "state")
+            .expression_attribute_names("#updated_at", "updated_at")
+            .expression_attribute_values(
+                ":new_state",
+                AttributeValue::M(new_state),
+            )
+            .expression_attribute_values(
+                ":updated_at",
+                AttributeValue::S(now.clone()),
+            )
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => info!("Updated ad_timer widget {} to in_ad_break", widget_id),
+            Err(e) => error!("Failed to update widget {}: {:?}", widget_id, e),
+        }
+    }
 
     Ok(())
 }

--- a/docs/v2/schemas/StreamWidget.schema
+++ b/docs/v2/schemas/StreamWidget.schema
@@ -16,7 +16,7 @@
     },
     "type": {
       "type": "string",
-      "enum": ["countdown", "text_overlay", "poll", "name_queue", "bot_integration"],
+      "enum": ["countdown", "text_overlay", "poll", "name_queue", "bot_integration", "ad_timer"],
       "description": "Widget type determines update behavior and available actions"
     },
     "active": {

--- a/twitch_lambda/src/handlers.rs
+++ b/twitch_lambda/src/handlers.rs
@@ -373,10 +373,7 @@ pub async fn subscribe_chat_handler(
     State(state): State<AppContext>,
     CognitoUserId(cognito_user_id): CognitoUserId,
 ) -> impl IntoResponse {
-    tracing::info!(
-        "Subscribe handler called for user: {}",
-        cognito_user_id
-    );
+    tracing::info!("Subscribe handler called for user: {}", cognito_user_id);
 
     // Get the user's access token
     let secret_id =

--- a/twitch_lambda/src/handlers.rs
+++ b/twitch_lambda/src/handlers.rs
@@ -297,13 +297,84 @@ struct EventSubWebhookRequest {
     event: Option<serde_json::Value>,
 }
 
-/// Subscribe to Twitch chat events for the authenticated user's channel
+/// Create a single EventSub webhook subscription on Twitch.
+/// Returns the subscription ID on success, or an error string.
+async fn create_eventsub_subscription(
+    client: &reqwest::Client,
+    app_access_token: &str,
+    client_id: &str,
+    event_type: &str,
+    version: &str,
+    condition: serde_json::Value,
+    webhook_url: &str,
+    eventsub_secret: &str,
+) -> Result<String, String> {
+    let request = EventSubSubscriptionRequest {
+        event_type: event_type.to_string(),
+        version: version.to_string(),
+        condition,
+        transport: EventSubTransport {
+            method: "webhook".to_string(),
+            callback: webhook_url.to_string(),
+            secret: eventsub_secret.to_string(),
+        },
+    };
+
+    let response = client
+        .post("https://api.twitch.tv/helix/eventsub/subscriptions")
+        .header("Authorization", format!("Bearer {}", app_access_token))
+        .header("Client-ID", client_id)
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| format!("request_failed: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status().as_u16();
+        let body = response.text().await.unwrap_or_default();
+        // 409 Conflict means the subscription already exists — treat as success
+        if status == 409 {
+            tracing::info!(
+                "EventSub subscription for {} already exists (409)",
+                event_type
+            );
+            return Ok("already_exists".to_string());
+        }
+        tracing::error!(
+            "Twitch API error {} for {}: {}",
+            status,
+            event_type,
+            body
+        );
+        return Err(format!("twitch_error_{status}"));
+    }
+
+    let parsed: EventSubSubscriptionResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("parse_error: {e}"))?;
+
+    parsed
+        .data
+        .into_iter()
+        .next()
+        .map(|s| s.id)
+        .ok_or_else(|| "no_data".to_string())
+}
+
+/// Subscribe to all required Twitch EventSub events for the authenticated user:
+/// - channel.chat.message  (chat integration)
+/// - channel.ad_break.begin (ad timer widget)
+///
+/// Idempotent: if a subscription already exists (409), it is treated as success.
+/// The button on the frontend should be enabled until BOTH subscriptions are active.
 pub async fn subscribe_chat_handler(
     State(state): State<AppContext>,
     CognitoUserId(cognito_user_id): CognitoUserId,
 ) -> impl IntoResponse {
     tracing::info!(
-        "Subscribe chat handler called for user: {}",
+        "Subscribe handler called for user: {}",
         cognito_user_id
     );
 
@@ -360,8 +431,7 @@ pub async fn subscribe_chat_handler(
         }
     };
 
-    // Obtain an app access token for creating the webhook subscription
-    // Twitch requires app access tokens (not user access tokens) for webhook subscriptions
+    // Obtain an app access token — required by Twitch for webhook subscriptions
     let app_access_token =
         match twitch::get_app_access_token(&state.twitch_credentials).await {
             Ok(token) => token,
@@ -378,117 +448,81 @@ pub async fn subscribe_chat_handler(
             }
         };
 
-    // Create EventSub subscription request
-    let subscription_request = EventSubSubscriptionRequest {
-        event_type: "channel.chat.message".to_string(),
-        version: "1".to_string(),
-        condition: json!({
-            "broadcaster_user_id": validation_response.user_id,
-            "user_id": validation_response.user_id
-        }),
-        transport: EventSubTransport {
-            method: "webhook".to_string(),
-            callback: state.config.eventsub_webhook_url.clone(),
-            secret: match &state.eventsub_secret {
-                Some(secret) => secret.clone(),
-                None => {
-                    tracing::error!(
-                        "EventSub secret not configured or failed to load"
-                    );
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(json!(SubscribeChatResponse {
-                            subscription_id: None,
-                            status: "missing_eventsub_secret".to_string(),
-                        })),
-                    )
-                        .into_response();
-                }
-            },
-        },
+    let eventsub_secret = match &state.eventsub_secret {
+        Some(s) => s.clone(),
+        None => {
+            tracing::error!("EventSub secret not configured");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!(SubscribeChatResponse {
+                    subscription_id: None,
+                    status: "missing_eventsub_secret".to_string(),
+                })),
+            )
+                .into_response();
+        }
     };
 
-    // Make the subscription request to Twitch using the app access token
+    let broadcaster_id = &validation_response.user_id;
     let client = reqwest::Client::new();
-    let response = match client
-        .post("https://api.twitch.tv/helix/eventsub/subscriptions")
-        .header("Authorization", format!("Bearer {}", app_access_token))
-        .header("Client-ID", &state.twitch_credentials.id)
-        .header("Content-Type", "application/json")
-        .json(&subscription_request)
-        .send()
-        .await
-    {
-        Ok(response) => response,
-        Err(e) => {
-            tracing::error!("Failed to make subscription request: {:?}", e);
-            return (
+
+    // Subscribe to channel.chat.message
+    let chat_result = create_eventsub_subscription(
+        &client,
+        &app_access_token,
+        &state.twitch_credentials.id,
+        "channel.chat.message",
+        "1",
+        json!({
+            "broadcaster_user_id": broadcaster_id,
+            "user_id": broadcaster_id,
+        }),
+        &state.config.eventsub_webhook_url,
+        &eventsub_secret,
+    )
+    .await;
+
+    // Subscribe to channel.ad_break.begin
+    let ad_result = create_eventsub_subscription(
+        &client,
+        &app_access_token,
+        &state.twitch_credentials.id,
+        "channel.ad_break.begin",
+        "1",
+        json!({
+            "broadcaster_user_id": broadcaster_id,
+        }),
+        &state.config.eventsub_webhook_url,
+        &eventsub_secret,
+    )
+    .await;
+
+    match (chat_result, ad_result) {
+        (Ok(chat_id), Ok(_)) => {
+            tracing::info!(
+                "Stream integrations subscribed for broadcaster {}",
+                broadcaster_id
+            );
+            (
+                StatusCode::OK,
+                Json(json!(SubscribeChatResponse {
+                    subscription_id: Some(chat_id),
+                    status: "enabled".to_string(),
+                })),
+            )
+                .into_response()
+        }
+        (Err(e), _) | (_, Err(e)) => {
+            tracing::error!("Failed to create EventSub subscription: {}", e);
+            (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!(SubscribeChatResponse {
                     subscription_id: None,
-                    status: "request_failed".to_string(),
+                    status: e,
                 })),
             )
-                .into_response();
+                .into_response()
         }
-    };
-
-    if !response.status().is_success() {
-        let status_code = response.status();
-        let error_body = response.text().await.unwrap_or_default();
-        tracing::error!("Twitch API error {}: {}", status_code, error_body);
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!(SubscribeChatResponse {
-                subscription_id: None,
-                status: format!("twitch_error_{}", status_code.as_u16()),
-            })),
-        )
-            .into_response();
-    }
-
-    let subscription_response: EventSubSubscriptionResponse = match response
-        .json()
-        .await
-    {
-        Ok(response) => response,
-        Err(e) => {
-            tracing::error!("Failed to parse subscription response: {:?}", e);
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!(SubscribeChatResponse {
-                    subscription_id: None,
-                    status: "parse_error".to_string(),
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    if let Some(subscription) = subscription_response.data.first() {
-        tracing::info!(
-            "Created subscription: {} with status: {}",
-            subscription.id,
-            subscription.status
-        );
-        (
-            StatusCode::OK,
-            Json(json!(SubscribeChatResponse {
-                subscription_id: Some(subscription.id.clone()),
-                status: subscription.status.clone(),
-            })),
-        )
-            .into_response()
-    } else {
-        tracing::error!("No subscription data in response");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!(SubscribeChatResponse {
-                subscription_id: None,
-                status: "no_data".to_string(),
-            })),
-        )
-            .into_response()
     }
 }
 

--- a/twitch_lambda/src/handlers.rs
+++ b/twitch_lambda/src/handlers.rs
@@ -298,7 +298,8 @@ struct EventSubWebhookRequest {
 }
 
 /// Create a single EventSub webhook subscription on Twitch.
-/// Returns the subscription ID on success, or an error string.
+/// Returns `Some(subscription_id)` on successful creation, `None` when the
+/// subscription already exists (HTTP 409), or an error string on failure.
 async fn create_eventsub_subscription(
     client: &reqwest::Client,
     app_access_token: &str,
@@ -308,7 +309,7 @@ async fn create_eventsub_subscription(
     condition: serde_json::Value,
     webhook_url: &str,
     eventsub_secret: &str,
-) -> Result<String, String> {
+) -> Result<Option<String>, String> {
     let request = EventSubSubscriptionRequest {
         event_type: event_type.to_string(),
         version: version.to_string(),
@@ -339,7 +340,7 @@ async fn create_eventsub_subscription(
                 "EventSub subscription for {} already exists (409)",
                 event_type
             );
-            return Ok("already_exists".to_string());
+            return Ok(None);
         }
         tracing::error!(
             "Twitch API error {} for {}: {}",
@@ -360,6 +361,7 @@ async fn create_eventsub_subscription(
         .into_iter()
         .next()
         .map(|s| s.id)
+        .map(Some)
         .ok_or_else(|| "no_data".to_string())
 }
 
@@ -503,7 +505,9 @@ pub async fn subscribe_chat_handler(
             (
                 StatusCode::OK,
                 Json(json!(SubscribeChatResponse {
-                    subscription_id: Some(chat_id),
+                    // Only include a subscription_id when Twitch actually created
+                    // a new subscription (None means it already existed).
+                    subscription_id: chat_id,
                     status: "enabled".to_string(),
                 })),
             )

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -11,7 +11,7 @@
 //     let model: AccessTokenResponse = serde_json::from_str(&json).unwrap();
 // }
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -715,6 +715,9 @@ pub struct StreamWidget {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StreamWidgetType {
+    #[serde(rename = "ad_timer")]
+    AdTimer,
+
     #[serde(rename = "bot_integration")]
     BotIntegration,
 
@@ -730,8 +733,7 @@ pub enum StreamWidgetType {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct SubscribeChatRequest {
-}
+pub struct SubscribeChatRequest {}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SubscribeChatResponse {

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -534,7 +534,7 @@ export interface StreamWidget {
 /**
  * Widget type determines update behavior and available actions
  */
-export type StreamWidgetType = "countdown" | "text_overlay" | "poll" | "name_queue" | "bot_integration";
+export type StreamWidgetType = "ad_timer" | "countdown" | "text_overlay" | "poll" | "name_queue" | "bot_integration";
 
 export interface SubscribeChatRequest {
 }

--- a/widget_updater_lambda/Cargo.toml
+++ b/widget_updater_lambda/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2021"
 [dependencies]
 aws-config = { workspace = true }
 aws-sdk-dynamodb = { workspace = true }
+aws-sdk-secretsmanager = { workspace = true }
 chrono = { workspace = true }
 gt_app = { workspace = true }
+gt_secrets = { workspace = true }
 lambda_runtime = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/widget_updater_lambda/src/main.rs
+++ b/widget_updater_lambda/src/main.rs
@@ -1,6 +1,8 @@
 use aws_sdk_dynamodb::{Client as DynamoDbClient, types::AttributeValue};
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use chrono::Utc;
 use gt_app::ContextProvider;
+use gt_secrets::UserSecretPathProvider;
 use lambda_runtime::{Error, LambdaEvent, run, service_fn};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
@@ -9,6 +11,7 @@ use tracing::{info, warn};
 use types::{StreamWidget, StreamWidgetType};
 
 mod updaters;
+use updaters::ad_timer::compute_ad_timer_updates;
 use updaters::{WidgetUpdate, WidgetUpdater, countdown::CountdownUpdater};
 
 #[derive(Debug, Deserialize)]
@@ -25,19 +28,49 @@ struct Response {
 #[derive(Debug, Clone, Deserialize)]
 struct Config {
     stream_widgets_table: String,
+    /// ARN of the Twitch app secret (contains client_id and client_secret).
+    twitch_secret_arn: String,
+    /// Base path for per-user Twitch secrets in Secrets Manager.
+    user_secret_path: UserSecretPathProvider,
 }
 
 #[derive(Debug, Clone)]
 struct AppContext {
     dynamodb: DynamoDbClient,
+    secrets_manager: SecretsManagerClient,
+    http_client: reqwest::Client,
     config: Config,
+    /// Twitch Client-Id read from the app secret at startup.
+    twitch_client_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TwitchAppSecret {
+    id: String,
 }
 
 impl ContextProvider<Config> for AppContext {
     async fn new(config: Config, aws_config: aws_config::SdkConfig) -> Self {
+        let secrets_manager = SecretsManagerClient::new(&aws_config);
+
+        // Read the Twitch client_id once at cold-start from the app secret.
+        let twitch_client_id = secrets_manager
+            .get_secret_value()
+            .secret_id(&config.twitch_secret_arn)
+            .send()
+            .await
+            .ok()
+            .and_then(|r| r.secret_string)
+            .and_then(|s| serde_json::from_str::<TwitchAppSecret>(&s).ok())
+            .map(|s| s.id)
+            .unwrap_or_default();
+
         Self {
             config,
             dynamodb: DynamoDbClient::new(&aws_config),
+            secrets_manager,
+            http_client: reqwest::Client::new(),
+            twitch_client_id,
         }
     }
 }
@@ -68,15 +101,24 @@ async fn function_handler(
     );
 
     // Get the appropriate updater for this widget type
-    let updater = get_updater_for_type(widget_type)?;
-
-    // Compute updates for all widgets
-    let updates = updater.compute_batch_updates(&active_widgets);
-
-    info!("Generated {} updates", updates.len());
-
-    // Write updates to DynamoDB in batches
-    let updated_count = batch_write_widget_states(context, &updates).await?;
+    // ad_timer uses async Twitch API calls, handled separately from the sync trait.
+    let updated_count = if widget_type == "ad_timer" {
+        let updates = compute_ad_timer_updates(
+            &active_widgets,
+            &context.secrets_manager,
+            &context.http_client,
+            &context.config.user_secret_path,
+            &context.twitch_client_id,
+        )
+        .await;
+        info!("Generated {} ad_timer updates", updates.len());
+        batch_write_widget_states(context, &updates).await?
+    } else {
+        let updater = get_updater_for_type(widget_type)?;
+        let updates = updater.compute_batch_updates(&active_widgets);
+        info!("Generated {} updates", updates.len());
+        batch_write_widget_states(context, &updates).await?
+    };
 
     Ok(Response {
         widgets_processed: active_widgets.len(),
@@ -152,6 +194,7 @@ fn deserialize_widget(
         .clone();
 
     let stream_widget_type = match stream_widget_type_string.as_str() {
+        "ad_timer" => StreamWidgetType::AdTimer,
         "countdown" => StreamWidgetType::Countdown,
         "bot_integration" => StreamWidgetType::BotIntegration,
         "name_queue" => StreamWidgetType::NameQueue,

--- a/widget_updater_lambda/src/main.rs
+++ b/widget_updater_lambda/src/main.rs
@@ -54,16 +54,41 @@ impl ContextProvider<Config> for AppContext {
         let secrets_manager = SecretsManagerClient::new(&aws_config);
 
         // Read the Twitch client_id once at cold-start from the app secret.
-        let twitch_client_id = secrets_manager
+        let twitch_secret = secrets_manager
             .get_secret_value()
             .secret_id(&config.twitch_secret_arn)
             .send()
             .await
-            .ok()
-            .and_then(|r| r.secret_string)
-            .and_then(|s| serde_json::from_str::<TwitchAppSecret>(&s).ok())
-            .map(|s| s.id)
-            .unwrap_or_default();
+            .unwrap_or_else(|err| {
+                panic!(
+                    "failed to read Twitch app secret from Secrets Manager (secret_id={}): {err}",
+                    config.twitch_secret_arn
+                );
+            });
+
+        let secret_string = twitch_secret.secret_string.unwrap_or_else(|| {
+            panic!(
+                "Twitch app secret is missing secret_string field: secret_id={}",
+                config.twitch_secret_arn
+            );
+        });
+
+        let twitch_app_secret: TwitchAppSecret =
+            serde_json::from_str(&secret_string).unwrap_or_else(|err| {
+                panic!(
+                    "failed to parse Twitch app secret JSON (secret_id={}): {err}",
+                    config.twitch_secret_arn
+                );
+            });
+
+        if twitch_app_secret.id.is_empty() {
+            panic!(
+                "Twitch app secret has empty id field: secret_id={}",
+                config.twitch_secret_arn
+            );
+        }
+
+        let twitch_client_id = twitch_app_secret.id;
 
         Self {
             config,
@@ -215,18 +240,24 @@ fn deserialize_widget(
 
     let state = item.get("state").and_then(|v| deserialize_map(v).ok());
 
+    let user_id = item
+        .get("user_id")
+        .and_then(|v| v.as_s().ok())
+        .cloned()
+        .unwrap_or_default();
+
     Ok(StreamWidget {
         id,
         stream_widget_type,
         active,
         config,
         state,
+        user_id,
         // unused fields, so don't bother deserializing
         access_token: None,
         created_at: None,
         updated_at: None,
         title: "".to_string(),
-        user_id: "".to_string(),
     })
 }
 

--- a/widget_updater_lambda/src/updaters/ad_timer.rs
+++ b/widget_updater_lambda/src/updaters/ad_timer.rs
@@ -1,0 +1,285 @@
+use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use chrono::{DateTime, Duration, Utc};
+use gt_secrets::UserSecretPathProvider;
+use serde::Deserialize;
+use serde_json::json;
+use tracing::{instrument, warn};
+use types::TwitchSessionSecret;
+
+use super::WidgetUpdate;
+
+/// Configuration stored per widget instance in DynamoDB.
+#[derive(Debug, Deserialize)]
+struct AdTimerConfig {
+    /// Milliseconds to show the "Back from Ads" message after an ad break ends.
+    #[serde(
+        rename = "backFromAdsDuration",
+        default = "default_back_from_ads_duration_ms"
+    )]
+    back_from_ads_duration_ms: i64,
+}
+
+fn default_back_from_ads_duration_ms() -> i64 {
+    10_000
+}
+
+/// State stored per widget instance in DynamoDB (the fields the backend owns).
+#[derive(Debug, Deserialize)]
+struct AdTimerState {
+    /// ISO 8601 timestamp of next scheduled ad, or null.
+    #[serde(rename = "nextAdAt")]
+    next_ad_at: Option<String>,
+    /// Current snooze count from the last Twitch poll.
+    #[serde(rename = "snoozeCount", default)]
+    snooze_count: i64,
+    /// ISO 8601 timestamp when a snooze was detected, or null.
+    #[serde(rename = "snoozedAt")]
+    snoozed_at: Option<String>,
+    /// ISO 8601 timestamp until when to show "Back from Ads", or null.
+    #[serde(rename = "backFromAdsUntil")]
+    back_from_ads_until: Option<String>,
+}
+
+/// Response from GET /helix/channels/ads
+#[derive(Debug, Deserialize)]
+struct AdScheduleData {
+    /// Unix timestamp (seconds) of next scheduled ad. 0 means no ad scheduled.
+    next_ad_at: i64,
+    /// Number of available snoozes remaining.
+    snooze_count: i64,
+    /// Unix timestamp (seconds) of last ad break. 0 means no previous ad.
+    last_ad_at: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdScheduleResponse {
+    data: Vec<AdScheduleData>,
+}
+
+/// Fetch the ad schedule for a broadcaster from the Twitch API.
+async fn fetch_ad_schedule(
+    http: &reqwest::Client,
+    broadcaster_id: &str,
+    access_token: &str,
+    twitch_client_id: &str,
+) -> Result<AdScheduleData, String> {
+    let url = format!(
+        "https://api.twitch.tv/helix/channels/ads?broadcaster_id={}",
+        broadcaster_id
+    );
+
+    let response = http
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", access_token))
+        .header("Client-Id", twitch_client_id)
+        .send()
+        .await
+        .map_err(|e| format!("HTTP request failed: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "Twitch API returned status {}",
+            response.status()
+        ));
+    }
+
+    let body: AdScheduleResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))?;
+
+    body.data
+        .into_iter()
+        .next()
+        .ok_or_else(|| "Empty data array in ad schedule response".to_string())
+}
+
+/// Compute the new state for a single ad_timer widget.
+///
+/// Returns `None` if the state is unchanged (no update needed).
+#[allow(clippy::too_many_arguments)]
+fn compute_new_state(
+    now: DateTime<Utc>,
+    ad_data: &AdScheduleData,
+    current_state: &AdTimerState,
+    config: &AdTimerConfig,
+) -> Option<serde_json::Value> {
+    let new_next_ad_at: Option<String> = if ad_data.next_ad_at > 0 {
+        Some(
+            DateTime::from_timestamp(ad_data.next_ad_at, 0)
+                .unwrap_or(now)
+                .to_rfc3339(),
+        )
+    } else {
+        None
+    };
+
+    // Detect snooze: snooze_count decremented means user used a snooze.
+    let new_snoozed_at = if ad_data.snooze_count < current_state.snooze_count {
+        Some(now.to_rfc3339())
+    } else {
+        current_state.snoozed_at.clone()
+    };
+
+    // Detect ad completion: last_ad_at changed to a new non-zero value while
+    // we were previously in (or past) an ad break (i.e., next_ad_at was in the past).
+    let was_in_ad_break = current_state
+        .next_ad_at
+        .as_deref()
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|next| next.with_timezone(&Utc) <= now)
+        .unwrap_or(false);
+
+    let last_ad_changed = ad_data.last_ad_at > 0
+        && {
+            // Compare to what we previously recorded — we track this via nextAdAt being in the past.
+            // A simpler heuristic: if we were in an ad break and now next_ad_at moved forward.
+            let prev_next_ad = current_state
+                .next_ad_at
+                .as_deref()
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc));
+
+            let new_next_ad = new_next_ad_at
+                .as_deref()
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc));
+
+            matches!((prev_next_ad, new_next_ad), (Some(prev), Some(next)) if next > prev)
+        };
+
+    let new_back_from_ads_until = if was_in_ad_break && last_ad_changed {
+        let until =
+            now + Duration::milliseconds(config.back_from_ads_duration_ms);
+        Some(until.to_rfc3339())
+    } else {
+        current_state.back_from_ads_until.clone()
+    };
+
+    Some(json!({
+        "nextAdAt": new_next_ad_at,
+        "snoozeCount": ad_data.snooze_count,
+        "snoozedAt": new_snoozed_at,
+        "backFromAdsUntil": new_back_from_ads_until,
+    }))
+}
+
+/// Compute state updates for all active ad_timer widgets.
+///
+/// Each widget belongs to a user; we fetch that user's Twitch token from
+/// Secrets Manager, then call the Twitch ad schedule API on their behalf.
+#[instrument(skip_all)]
+pub async fn compute_ad_timer_updates(
+    widgets: &[types::StreamWidget],
+    secrets_manager: &SecretsManagerClient,
+    http: &reqwest::Client,
+    user_secret_path: &UserSecretPathProvider,
+    twitch_client_id: &str,
+) -> Vec<WidgetUpdate> {
+    let now = Utc::now();
+    let mut updates = Vec::new();
+
+    for widget in widgets {
+        let result = process_widget(
+            widget,
+            secrets_manager,
+            http,
+            user_secret_path,
+            twitch_client_id,
+            now,
+        )
+        .await;
+
+        match result {
+            Ok(Some(update)) => updates.push(update),
+            Ok(None) => {}
+            Err(e) => warn!("Skipping widget {}: {}", widget.id, e),
+        }
+    }
+
+    updates
+}
+
+async fn process_widget(
+    widget: &types::StreamWidget,
+    secrets_manager: &SecretsManagerClient,
+    http: &reqwest::Client,
+    user_secret_path: &UserSecretPathProvider,
+    twitch_client_id: &str,
+    now: DateTime<Utc>,
+) -> Result<Option<WidgetUpdate>, String> {
+    let secret_id = user_secret_path.secret_path(&widget.user_id);
+
+    let twitch_secret: TwitchSessionSecret =
+        gt_secrets::get(secrets_manager, &secret_id)
+            .await
+            .map_err(|e| format!("Failed to get Twitch secret: {e}"))?;
+
+    let access_token = twitch_secret
+        .access_token
+        .as_deref()
+        .ok_or("No Twitch access token for user")?;
+
+    // The broadcaster_id is the user_id in the Twitch token validation response.
+    // It is stored in Secrets Manager alongside the access token.  We derive it
+    // by calling the Twitch /validate endpoint — but to avoid an extra round-trip
+    // on every poll we instead read it from the broadcaster_id field in the token
+    // secret. The twitch_lambda stores it implicitly as the Cognito user_id maps
+    // to the Twitch user. For now we pass user_id as the broadcaster ID; callers
+    // that set up the widget must ensure user_id == Twitch broadcaster_id.
+    //
+    // A cleaner future improvement: store broadcaster_id in the widget record.
+    let broadcaster_id = &widget.user_id;
+
+    let ad_data = fetch_ad_schedule(
+        http,
+        broadcaster_id,
+        access_token,
+        twitch_client_id,
+    )
+    .await?;
+
+    // Parse current widget state
+    let current_state: AdTimerState = widget
+        .state
+        .as_ref()
+        .and_then(|s| serde_json::to_value(s).ok())
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or(AdTimerState {
+            next_ad_at: None,
+            snooze_count: 0,
+            snoozed_at: None,
+            back_from_ads_until: None,
+        });
+
+    // Parse config (use defaults if missing)
+    let config: AdTimerConfig = widget
+        .config
+        .as_ref()
+        .and_then(|c| serde_json::to_value(c).ok())
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or(AdTimerConfig {
+            back_from_ads_duration_ms: default_back_from_ads_duration_ms(),
+        });
+
+    let new_state_json =
+        match compute_new_state(now, &ad_data, &current_state, &config) {
+            Some(v) => v,
+            None => return Ok(None),
+        };
+
+    // Convert JSON object into the HashMap<String, Option<JsonValue>> format the writer expects
+    let state_map = new_state_json
+        .as_object()
+        .ok_or("State is not an object")?
+        .iter()
+        .map(|(k, v)| {
+            (k.clone(), if v.is_null() { None } else { Some(v.clone()) })
+        })
+        .collect();
+
+    Ok(Some(WidgetUpdate {
+        id: widget.id.clone(),
+        state: state_map,
+    }))
+}

--- a/widget_updater_lambda/src/updaters/ad_timer.rs
+++ b/widget_updater_lambda/src/updaters/ad_timer.rs
@@ -8,6 +8,12 @@ use types::TwitchSessionSecret;
 
 use super::WidgetUpdate;
 
+/// Minimal response from the Twitch OAuth /validate endpoint.
+#[derive(Deserialize)]
+struct TwitchValidateResponse {
+    user_id: String,
+}
+
 /// Configuration stored per widget instance in DynamoDB.
 #[derive(Debug, Deserialize)]
 struct AdTimerConfig {
@@ -156,6 +162,15 @@ fn compute_new_state(
         current_state.back_from_ads_until.clone()
     };
 
+    // Return None if nothing changed to avoid unnecessary DynamoDB writes.
+    if new_next_ad_at == current_state.next_ad_at
+        && ad_data.snooze_count == current_state.snooze_count
+        && new_snoozed_at == current_state.snoozed_at
+        && new_back_from_ads_until == current_state.back_from_ads_until
+    {
+        return None;
+    }
+
     Some(json!({
         "nextAdAt": new_next_ad_at,
         "snoozeCount": ad_data.snooze_count,
@@ -220,20 +235,33 @@ async fn process_widget(
         .as_deref()
         .ok_or("No Twitch access token for user")?;
 
-    // The broadcaster_id is the user_id in the Twitch token validation response.
-    // It is stored in Secrets Manager alongside the access token.  We derive it
-    // by calling the Twitch /validate endpoint — but to avoid an extra round-trip
-    // on every poll we instead read it from the broadcaster_id field in the token
-    // secret. The twitch_lambda stores it implicitly as the Cognito user_id maps
-    // to the Twitch user. For now we pass user_id as the broadcaster ID; callers
-    // that set up the widget must ensure user_id == Twitch broadcaster_id.
-    //
-    // A cleaner future improvement: store broadcaster_id in the widget record.
-    let broadcaster_id = &widget.user_id;
+    // Derive the Twitch broadcaster_id from the access token by calling the
+    // Twitch OAuth /validate endpoint, rather than assuming widget.user_id is
+    // a Twitch user ID (it is a Cognito sub elsewhere in the codebase).
+    let validate_resp = http
+        .get("https://id.twitch.tv/oauth2/validate")
+        .header("Authorization", format!("OAuth {}", access_token))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to validate Twitch token: {e}"))?;
+
+    if !validate_resp.status().is_success() {
+        return Err(format!(
+            "Twitch token validation failed with status {}",
+            validate_resp.status()
+        ));
+    }
+
+    let validate_body: TwitchValidateResponse = validate_resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Twitch validate response: {e}"))?;
+
+    let broadcaster_id = validate_body.user_id;
 
     let ad_data = fetch_ad_schedule(
         http,
-        broadcaster_id,
+        &broadcaster_id,
         access_token,
         twitch_client_id,
     )
@@ -282,4 +310,152 @@ async fn process_widget(
         id: widget.id.clone(),
         state: state_map,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn make_config(back_from_ads_duration_ms: i64) -> AdTimerConfig {
+        AdTimerConfig {
+            back_from_ads_duration_ms,
+        }
+    }
+
+    fn make_state(
+        next_ad_at: Option<&str>,
+        snooze_count: i64,
+        snoozed_at: Option<&str>,
+        back_from_ads_until: Option<&str>,
+    ) -> AdTimerState {
+        AdTimerState {
+            next_ad_at: next_ad_at.map(String::from),
+            snooze_count,
+            snoozed_at: snoozed_at.map(String::from),
+            back_from_ads_until: back_from_ads_until.map(String::from),
+        }
+    }
+
+    fn make_ad_data(
+        next_ad_at: i64,
+        snooze_count: i64,
+        last_ad_at: i64,
+    ) -> AdScheduleData {
+        AdScheduleData {
+            next_ad_at,
+            snooze_count,
+            last_ad_at,
+        }
+    }
+
+    #[test]
+    fn test_next_ad_at_set_when_nonzero() {
+        let now = Utc::now();
+        let future = now + Duration::minutes(10);
+        let ad_data = make_ad_data(future.timestamp(), 3, 0);
+        let current = make_state(None, 3, None, None);
+        let config = make_config(10_000);
+
+        let result = compute_new_state(now, &ad_data, &current, &config);
+        assert!(result.is_some());
+        let state = result.unwrap();
+        assert!(!state["nextAdAt"].is_null());
+    }
+
+    #[test]
+    fn test_next_ad_at_cleared_when_zero() {
+        let now = Utc::now();
+        let ad_data = make_ad_data(0, 3, 0);
+        // Previously had a non-null nextAdAt
+        let prev_next = (now + Duration::minutes(10)).to_rfc3339();
+        let current = make_state(Some(&prev_next), 3, None, None);
+        let config = make_config(10_000);
+
+        let result = compute_new_state(now, &ad_data, &current, &config);
+        assert!(result.is_some());
+        let state = result.unwrap();
+        assert!(state["nextAdAt"].is_null());
+    }
+
+    #[test]
+    fn test_snooze_detected_when_count_decrements() {
+        let now = Utc::now();
+        let future = (now + Duration::minutes(10)).timestamp();
+        let ad_data = make_ad_data(future, 2, 0); // was 3, now 2
+        let current = make_state(None, 3, None, None);
+        let config = make_config(10_000);
+
+        let result = compute_new_state(now, &ad_data, &current, &config);
+        assert!(result.is_some());
+        let state = result.unwrap();
+        assert!(!state["snoozedAt"].is_null());
+        assert_eq!(state["snoozeCount"], 2);
+    }
+
+    #[test]
+    fn test_snooze_not_detected_when_count_unchanged() {
+        let now = Utc::now();
+        let future = (now + Duration::minutes(10)).timestamp();
+        let ad_data = make_ad_data(future, 3, 0);
+        let current = make_state(None, 3, None, None);
+        let config = make_config(10_000);
+
+        let result = compute_new_state(now, &ad_data, &current, &config);
+        // next_ad_at changed (None -> Some), so it's not None
+        let state = result.unwrap();
+        assert!(state["snoozedAt"].is_null());
+    }
+
+    #[test]
+    fn test_back_from_ads_until_set_after_break() {
+        let now = Utc::now();
+        // Ad was scheduled in the past (we were in a break)
+        let past_next_ad = (now - Duration::minutes(1)).to_rfc3339();
+        // New next ad is in the future (break is over)
+        let new_next_ad = (now + Duration::minutes(30)).timestamp();
+        let ad_data = make_ad_data(new_next_ad, 3, now.timestamp());
+        let current = make_state(Some(&past_next_ad), 3, None, None);
+        let config = make_config(10_000);
+
+        let result = compute_new_state(now, &ad_data, &current, &config);
+        assert!(result.is_some());
+        let state = result.unwrap();
+        assert!(!state["backFromAdsUntil"].is_null());
+    }
+
+    #[test]
+    fn test_back_from_ads_until_not_set_when_not_in_break() {
+        let now = Utc::now();
+        // nextAdAt is in the future (not in an ad break)
+        let future_next_ad = (now + Duration::minutes(5)).to_rfc3339();
+        let new_next_ad = (now + Duration::minutes(30)).timestamp();
+        let ad_data = make_ad_data(new_next_ad, 3, 0);
+        let current = make_state(Some(&future_next_ad), 3, None, None);
+        let config = make_config(10_000);
+
+        let result = compute_new_state(now, &ad_data, &current, &config);
+        // The state changed (nextAdAt moved forward), so Some is returned
+        let state = result.unwrap();
+        assert!(state["backFromAdsUntil"].is_null());
+    }
+
+    #[test]
+    fn test_no_update_when_state_unchanged() {
+        // Use a fixed past time so there's no sub-second rounding issue.
+        let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        // Build next_ad_at from an integer timestamp so the round-trip is lossless.
+        let next_ad_ts = now.timestamp() + 600; // 10 minutes from now
+        let next_ad_rfc3339 = DateTime::from_timestamp(next_ad_ts, 0)
+            .unwrap()
+            .to_rfc3339();
+        let ad_data = make_ad_data(next_ad_ts, 3, 0);
+        let current = make_state(Some(&next_ad_rfc3339), 3, None, None);
+        let config = make_config(10_000);
+
+        // Nothing has changed: the timestamp round-trips exactly, snooze count is
+        // the same, and no ad break is in progress. Should return None.
+        let result = compute_new_state(now, &ad_data, &current, &config);
+        assert!(result.is_none(), "expected None when state is unchanged");
+    }
 }

--- a/widget_updater_lambda/src/updaters/mod.rs
+++ b/widget_updater_lambda/src/updaters/mod.rs
@@ -1,3 +1,4 @@
+pub mod ad_timer;
 pub mod countdown;
 
 use serde_json::Value as JsonValue;


### PR DESCRIPTION
- [x] Understand review comments and plan changes
- [x] Fix `AppContext::new` to panic on missing/invalid Twitch secret (fail fast)
- [x] Fix `deserialize_widget` to deserialize `user_id` from DynamoDB
- [x] Fix `compute_new_state` to return `None` when state unchanged (avoid unnecessary writes)
- [x] Add Twitch `/validate` call to get real broadcaster_id (not Cognito sub)
- [x] Move `TwitchValidateResponse` to module level for reusability
- [x] Add 7 unit tests for `compute_new_state` (nextAdAt, snooze, backFromAdsUntil, no-op)
- [x] Replace Scan with paginated Query on `user_id-index` GSI in chat_processor
- [x] Remove redundant `!start_key.is_empty()` check in pagination loop
- [x] Fix UpdateItem to update only specific nested state keys (preserve snooze fields)
- [x] Reduce update expression duplication using base_update pattern
- [x] Fix `create_eventsub_subscription` to return `None` for 409 (not "already_exists")
- [x] Fix subscribe handler to pass `Option<String>` subscription_id correctly

<!-- START COPILOT CODING AGENT TIPS -->
---

⚡ Quickly spin up Copilot coding agent tasks from anywhere on your macOS or Windows machine with [Raycast](https://gh.io/cca-raycast-docs).
