### PR TITLE
Add per-second audio peaks extraction and backfill functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +171,24 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "audio_peaks_backfill"
+version = "0.1.0"
+dependencies = [
+ "aws-config",
+ "aws-sdk-dynamodb",
+ "aws-sdk-s3",
+ "clap",
+ "figment",
+ "gt_ffmpeg",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "audio_transcriber"
@@ -1018,6 +1086,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1133,12 @@ checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2293,6 +2407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "iso8601"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +2810,12 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openai_dive"
@@ -4650,6 +4776,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "embedding_service",
   "widget_updater_lambda",
   "ingestion_management_lambda",
+  "audio_peaks_backfill",
 ]
 
 [workspace.package]

--- a/audio_peaks_backfill/Cargo.toml
+++ b/audio_peaks_backfill/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "audio_peaks_backfill"
+description = "Backfill tool to compute per-second audio peaks for already-ingested video clips"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "audio_peaks_backfill"
+path = "src/main.rs"
+
+[dependencies]
+gt_ffmpeg = { path = "../gt_ffmpeg" }
+aws-sdk-s3 = { workspace = true }
+aws-sdk-dynamodb = { workspace = true }
+aws-config = { workspace = true }
+tokio = { workspace = true }
+figment = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tempfile = "3"
+clap = { version = "4", features = ["derive"] }
+
+[lints]
+workspace = true

--- a/audio_peaks_backfill/src/main.rs
+++ b/audio_peaks_backfill/src/main.rs
@@ -1,0 +1,291 @@
+use aws_config::{BehaviorVersion, SdkConfig, meta::region::RegionProviderChain};
+use aws_sdk_dynamodb::{Client as DynamoClient, types::AttributeValue};
+use aws_sdk_s3::{Client as S3Client, primitives::ByteStream};
+use clap::Parser;
+use figment::{Figment, providers::Env};
+use serde::Deserialize;
+use tokio::io::AsyncWriteExt;
+
+/// Compute per-second audio peak amplitudes for already-ingested video clips
+/// and write `{ peaks, duration }` JSON to S3, then update DynamoDB.
+///
+/// Reads existing WAV files from the output bucket (stored under `audio/`),
+/// so no re-extraction from the raw video archive is needed.
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+#[clap(group = clap::ArgGroup::new("mode").required(true).args(["item_key", "scan"]))]
+struct Args {
+    /// Process a single video clip by its DynamoDB partition key.
+    #[arg(long)]
+    item_key: Option<String>,
+
+    /// Scan all DynamoDB items that are missing the 'peaks' attribute.
+    #[arg(long)]
+    scan: bool,
+
+    /// Print what would be done without writing anything to S3 or DynamoDB.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[derive(Deserialize, Debug)]
+struct Config {
+    /// Bucket that holds the extracted WAV files (same as output bucket).
+    input_bucket: String,
+    /// Bucket to write peaks JSON to (same bucket as above in practice).
+    output_bucket: String,
+    /// S3 key prefix for peaks JSON files, e.g. "peaks".
+    peaks_prefix: String,
+    /// Name of the DynamoDB videoMetadataTable.
+    dynamodb_table: String,
+}
+
+fn load_config() -> Config {
+    Figment::new()
+        .merge(Env::raw())
+        .extract()
+        .expect("failed to load config from environment variables")
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let args = Args::parse();
+    let config = load_config();
+
+    let region_provider =
+        RegionProviderChain::default_provider().or_else("us-east-1");
+    let aws_config = aws_config::defaults(BehaviorVersion::latest())
+        .region(region_provider)
+        .load()
+        .await;
+
+    if let Some(ref key) = args.item_key {
+        process_single_item(&aws_config, &config, key, args.dry_run).await;
+    } else {
+        process_all_items(&aws_config, &config, args.dry_run).await;
+    }
+}
+
+/// Fetch a single DynamoDB item by its partition key and process it.
+async fn process_single_item(
+    aws_config: &SdkConfig,
+    config: &Config,
+    item_key: &str,
+    dry_run: bool,
+) {
+    let dynamo = DynamoClient::new(aws_config);
+
+    let response = dynamo
+        .get_item()
+        .table_name(&config.dynamodb_table)
+        .key("key", AttributeValue::S(item_key.to_string()))
+        .send()
+        .await
+        .expect("failed to fetch item from DynamoDB");
+
+    let item = match response.item {
+        Some(item) => item,
+        None => {
+            tracing::warn!("No item found for key: {}", item_key);
+            return;
+        }
+    };
+
+    process_item(aws_config, config, &item, dry_run).await;
+}
+
+/// Scan all DynamoDB items missing the `peaks` attribute and process each one.
+async fn process_all_items(
+    aws_config: &SdkConfig,
+    config: &Config,
+    dry_run: bool,
+) {
+    let dynamo = DynamoClient::new(aws_config);
+
+    let mut exclusive_start_key: Option<std::collections::HashMap<String, AttributeValue>> = None;
+    let mut total = 0usize;
+    let mut processed = 0usize;
+
+    loop {
+        let mut req = dynamo
+            .scan()
+            .table_name(&config.dynamodb_table)
+            .filter_expression("attribute_not_exists(peaks)");
+
+        if let Some(ref last_key) = exclusive_start_key {
+            req = req.set_exclusive_start_key(Some(last_key.clone()));
+        }
+
+        let response = req.send().await.expect("DynamoDB scan failed");
+
+        let items = response.items.unwrap_or_default();
+        total += items.len();
+
+        for item in &items {
+            let key = item
+                .get("key")
+                .and_then(|v| v.as_s().ok())
+                .map(String::as_str)
+                .unwrap_or("<unknown>");
+
+            tracing::info!("Processing item: {}", key);
+            process_item(aws_config, config, item, dry_run).await;
+            processed += 1;
+        }
+
+        exclusive_start_key = response.last_evaluated_key;
+        if exclusive_start_key.is_none() {
+            break;
+        }
+    }
+
+    tracing::info!(
+        "Scan complete: {} items found, {} processed",
+        total,
+        processed
+    );
+}
+
+/// Process one DynamoDB item: download its WAV, compute peaks, upload JSON,
+/// and update DynamoDB.
+async fn process_item(
+    aws_config: &SdkConfig,
+    config: &Config,
+    item: &std::collections::HashMap<String, AttributeValue>,
+    dry_run: bool,
+) {
+    let item_key = match item.get("key").and_then(|v| v.as_s().ok()) {
+        Some(k) => k.clone(),
+        None => {
+            tracing::warn!("Item is missing 'key' attribute, skipping");
+            return;
+        }
+    };
+
+    let audio_s3_key = match item.get("audio").and_then(|v| v.as_s().ok()) {
+        Some(k) => k.clone(),
+        None => {
+            tracing::warn!(
+                "Item '{}' has no 'audio' attribute, skipping",
+                item_key
+            );
+            return;
+        }
+    };
+
+    tracing::info!(
+        "Computing peaks for '{}' from WAV '{}'",
+        item_key,
+        audio_s3_key
+    );
+
+    // Download the WAV to a temp file.
+    let wav_path = download_wav(aws_config, &config.input_bucket, &audio_s3_key).await;
+
+    // Compute peaks.
+    let audio_peaks = gt_ffmpeg::audio_peaks::extract(&wav_path)
+        .await
+        .expect("failed to compute audio peaks");
+
+    let peaks_s3_key = format!("{}/{}.json", config.peaks_prefix, audio_s3_key);
+
+    if dry_run {
+        tracing::info!(
+            "[dry-run] Would upload {} peaks ({:.1}s) to s3://{}/{}",
+            audio_peaks.peaks.len(),
+            audio_peaks.duration,
+            config.output_bucket,
+            peaks_s3_key,
+        );
+        tracing::info!(
+            "[dry-run] Would update DynamoDB item '{}' with peaks = '{}'",
+            item_key,
+            peaks_s3_key,
+        );
+        return;
+    }
+
+    // Serialize and upload JSON.
+    let json_bytes = serde_json::to_vec(&serde_json::json!({
+        "peaks": audio_peaks.peaks,
+        "duration": audio_peaks.duration,
+    }))
+    .expect("failed to serialize peaks JSON");
+
+    let s3 = S3Client::new(aws_config);
+    s3.put_object()
+        .bucket(&config.output_bucket)
+        .key(&peaks_s3_key)
+        .body(ByteStream::from(json_bytes))
+        .content_type("application/json")
+        .send()
+        .await
+        .expect("failed to upload peaks JSON to S3");
+
+    tracing::info!("Uploaded peaks to s3://{}/{}", config.output_bucket, peaks_s3_key);
+
+    // Update DynamoDB.
+    let dynamo = DynamoClient::new(aws_config);
+    dynamo
+        .update_item()
+        .table_name(&config.dynamodb_table)
+        .key("key", AttributeValue::S(item_key.clone()))
+        .update_expression("SET peaks = :peaks")
+        .expression_attribute_values(":peaks", AttributeValue::S(peaks_s3_key.clone()))
+        .send()
+        .await
+        .expect("failed to update DynamoDB item with peaks key");
+
+    tracing::info!("Updated DynamoDB item '{}' with peaks = '{}'", item_key, peaks_s3_key);
+}
+
+/// Download an S3 object to a temp file and return the file path.
+async fn download_wav(
+    aws_config: &SdkConfig,
+    bucket: &str,
+    key: &str,
+) -> String {
+    let s3 = S3Client::new(aws_config);
+
+    let wav_path = tempfile::NamedTempFile::new()
+        .expect("failed to create temp file")
+        .into_temp_path()
+        .to_str()
+        .expect("temp path is not valid UTF-8")
+        .to_string();
+
+    let mut object = s3
+        .get_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .expect("failed to download WAV from S3");
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&wav_path)
+        .await
+        .expect("failed to open temp file for writing");
+
+    while let Some(chunk) = object
+        .body
+        .try_next()
+        .await
+        .expect("error reading S3 object body")
+    {
+        file.write_all(&chunk)
+            .await
+            .expect("failed to write chunk to temp file");
+    }
+
+    file.flush().await.expect("failed to flush temp file");
+
+    tracing::info!("Downloaded WAV to {}", wav_path);
+
+    wav_path
+}

--- a/cdk/lib/batch/videoIngestorJob.ts
+++ b/cdk/lib/batch/videoIngestorJob.ts
@@ -84,6 +84,7 @@ export default class VideoIngestorConstruct extends Construct {
           KEYFRAMES_PREFIX: 'keyframes',
           TRANSCODE_PREFIX: 'transcode',
           AUDIO_PREFIX: 'audio',
+          PEAKS_PREFIX: 'peaks',
           DYNAMODB_TABLE: props.videoMetadataTable.tableName,
           SPEECH_TRACK_NUMBER: '1', // as of 2025-08-03, this is now track 1 instead of 2
           NOISE_TOLERANCE: '0.004',

--- a/gt_ffmpeg/src/audio_peaks.rs
+++ b/gt_ffmpeg/src/audio_peaks.rs
@@ -3,7 +3,7 @@ use tokio::process::Command;
 /// Per-second peak amplitudes extracted from a WAV file.
 #[derive(Debug)]
 pub struct AudioPeaks {
-    /// One peak amplitude value per second of audio.
+    /// One peak amplitude (dB) per second of audio.
     pub peaks: Vec<f64>,
     /// Duration in seconds (equals `peaks.len()` as a float).
     pub duration: f64,
@@ -11,14 +11,21 @@ pub struct AudioPeaks {
 
 /// Extract per-second peak amplitudes from a WAV file.
 ///
-/// Uses ffmpeg's `astats` filter with `reset=16000` (one measurement per 16 000
-/// samples, matching the 16 kHz mono WAV produced by `audio_extraction::extract`).
+/// Uses the ffmpeg filter chain:
+///   `asetnsamples=n=16000,astats=metadata=1:reset=1,ametadata=print:file=-`
+///
+/// `asetnsamples` rechunks the audio into exactly 16 000-sample frames
+/// (= 1 second at 16 kHz mono), then `astats` with `reset=1` computes fresh
+/// stats for each frame. `ametadata=print:file=-` writes the lavfi metadata
+/// to stdout, one block per frame.
+///
+/// The peak value extracted is `lavfi.astats.1.Peak_level` (dB).
 ///
 /// # Arguments
-/// * `wav_path` - Path to the WAV file on disk.
+/// * `wav_path` - Path to the 16 kHz mono WAV file on disk.
 ///
 /// # Returns
-/// An [`AudioPeaks`] containing one peak value per second and the total duration.
+/// An [`AudioPeaks`] containing one peak dB value per second and the total duration.
 ///
 /// # Errors
 /// Returns an error if ffmpeg fails to run or its output cannot be parsed.
@@ -33,23 +40,25 @@ pub async fn extract(
         .arg("-i")
         .arg(wav_path)
         .arg("-af")
-        .arg("astats=metadata=1:reset=16000")
+        .arg("asetnsamples=n=16000,astats=metadata=1:reset=1,ametadata=print:file=-")
         .arg("-f")
         .arg("null")
         .arg("-")
         .output()
         .await?;
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    tracing::trace!("ffmpeg astats output: {}", stderr);
-
-    if !output.status.success() && !stderr.contains("lavfi.astats") {
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
         tracing::error!("ffmpeg astats failed: {}", stderr);
         return Err("ffmpeg astats failed".into());
     }
 
-    let peaks = parse_peaks(&stderr);
+    // ametadata writes to stdout (file=-)
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    tracing::trace!("ffmpeg ametadata output: {}", stdout);
+
+    let peaks = parse_peaks(&stdout);
 
     let duration = peaks.len() as f64;
 
@@ -62,12 +71,12 @@ pub async fn extract(
     Ok(AudioPeaks { peaks, duration })
 }
 
-/// Parse `lavfi.astats.Overall.Peak_amplitude=<value>` lines from ffmpeg stderr.
-fn parse_peaks(stderr: &str) -> Vec<f64> {
-    stderr
+/// Parse `lavfi.astats.1.Peak_level=<value>` lines from ametadata stdout output.
+fn parse_peaks(stdout: &str) -> Vec<f64> {
+    stdout
         .lines()
         .filter_map(|line| {
-            let marker = "lavfi.astats.Overall.Peak_amplitude=";
+            let marker = "lavfi.astats.1.Peak_level=";
             let pos = line.find(marker)?;
             let value_str = line[pos + marker.len()..].trim();
             value_str.parse::<f64>().ok()
@@ -81,14 +90,17 @@ mod tests {
 
     #[test]
     fn test_parse_peaks_basic() {
-        let stderr = "\
-[Parsed_astats_0 @ 0x...] lavfi.astats.Overall.Peak_amplitude=0.123456\n\
-[Parsed_astats_0 @ 0x...] lavfi.astats.Overall.Peak_amplitude=0.654321\n\
-[Parsed_astats_0 @ 0x...] lavfi.astats.Overall.Peak_amplitude=0.000000\n";
-        let peaks = parse_peaks(stderr);
+        let stdout = "\
+frame:0    pts:0       pts_time:0\n\
+lavfi.astats.1.Peak_level=-18.063656\n\
+frame:1    pts:16000   pts_time:1\n\
+lavfi.astats.1.Peak_level=-21.500000\n\
+frame:2    pts:32000   pts_time:2\n\
+lavfi.astats.1.Peak_level=0.000000\n";
+        let peaks = parse_peaks(stdout);
         assert_eq!(peaks.len(), 3);
-        assert!((peaks[0] - 0.123_456).abs() < 1e-6);
-        assert!((peaks[1] - 0.654_321).abs() < 1e-6);
+        assert!((peaks[0] - -18.063_656).abs() < 1e-4);
+        assert!((peaks[1] - -21.5).abs() < 1e-6);
         assert!((peaks[2]).abs() < 1e-9);
     }
 

--- a/gt_ffmpeg/src/audio_peaks.rs
+++ b/gt_ffmpeg/src/audio_peaks.rs
@@ -58,7 +58,10 @@ pub async fn extract(
 
     tracing::trace!("ffmpeg ametadata output: {}", stdout);
 
-    let peaks = parse_peaks(&stdout);
+    let peaks: Vec<f64> = parse_peaks(&stdout)
+        .into_iter()
+        .map(db_to_amplitude)
+        .collect();
 
     let duration = peaks.len() as f64;
 
@@ -69,6 +72,14 @@ pub async fn extract(
     );
 
     Ok(AudioPeaks { peaks, duration })
+}
+
+/// Convert a dBFS value to a linear amplitude in [0.0, 1.0].
+///
+/// Formula: `amplitude = 10^(db / 20)`, clamped to [0.0, 1.0].
+/// Silence (e.g. −84 dB or lower) maps to ~0.0; 0 dBFS maps to 1.0.
+fn db_to_amplitude(db: f64) -> f64 {
+    (10_f64.powf(db / 20.0)).clamp(0.0, 1.0)
 }
 
 /// Parse `lavfi.astats.1.Peak_level=<value>` lines from ametadata stdout output.
@@ -86,7 +97,7 @@ fn parse_peaks(stdout: &str) -> Vec<f64> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_peaks;
+    use super::{db_to_amplitude, parse_peaks};
 
     #[test]
     fn test_parse_peaks_basic() {
@@ -108,5 +119,32 @@ lavfi.astats.1.Peak_level=0.000000\n";
     fn test_parse_peaks_empty() {
         let peaks = parse_peaks("no matching lines here\n");
         assert!(peaks.is_empty());
+    }
+
+    #[test]
+    fn test_db_to_amplitude_zero_dbfs() {
+        // 0 dBFS = full scale = 1.0
+        assert!((db_to_amplitude(0.0) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_db_to_amplitude_silence() {
+        // -84 dBFS ≈ 0.00006, effectively silence
+        let a = db_to_amplitude(-84.0);
+        assert!(a < 0.001);
+        assert!(a >= 0.0);
+    }
+
+    #[test]
+    fn test_db_to_amplitude_minus_6() {
+        // -6 dBFS ≈ 0.501 (half amplitude)
+        let a = db_to_amplitude(-6.0);
+        assert!((a - 0.501_187).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_db_to_amplitude_clamped() {
+        // Values above 0 dBFS (e.g. due to clipping) clamp to 1.0
+        assert!((db_to_amplitude(3.0) - 1.0).abs() < 1e-9);
     }
 }

--- a/gt_ffmpeg/src/audio_peaks.rs
+++ b/gt_ffmpeg/src/audio_peaks.rs
@@ -3,9 +3,9 @@ use tokio::process::Command;
 /// Per-second peak amplitudes extracted from a WAV file.
 #[derive(Debug)]
 pub struct AudioPeaks {
-    /// One peak amplitude (dB) per second of audio.
+    /// One peak amplitude (linear, 0.0..=1.0) per second of audio.
     pub peaks: Vec<f64>,
-    /// Duration in seconds (equals `peaks.len()` as a float).
+    /// Duration in seconds (typically equals `peaks.len()`).
     pub duration: f64,
 }
 

--- a/gt_ffmpeg/src/audio_peaks.rs
+++ b/gt_ffmpeg/src/audio_peaks.rs
@@ -1,0 +1,100 @@
+use tokio::process::Command;
+
+/// Per-second peak amplitudes extracted from a WAV file.
+#[derive(Debug)]
+pub struct AudioPeaks {
+    /// One peak amplitude value per second of audio.
+    pub peaks: Vec<f64>,
+    /// Duration in seconds (equals `peaks.len()` as a float).
+    pub duration: f64,
+}
+
+/// Extract per-second peak amplitudes from a WAV file.
+///
+/// Uses ffmpeg's `astats` filter with `reset=16000` (one measurement per 16 000
+/// samples, matching the 16 kHz mono WAV produced by `audio_extraction::extract`).
+///
+/// # Arguments
+/// * `wav_path` - Path to the WAV file on disk.
+///
+/// # Returns
+/// An [`AudioPeaks`] containing one peak value per second and the total duration.
+///
+/// # Errors
+/// Returns an error if ffmpeg fails to run or its output cannot be parsed.
+#[tracing::instrument]
+pub async fn extract(
+    wav_path: &str,
+) -> Result<AudioPeaks, Box<dyn std::error::Error>> {
+    tracing::info!("Extracting audio peaks from {}", wav_path);
+
+    let output = Command::new("ffmpeg")
+        .arg("-hide_banner")
+        .arg("-i")
+        .arg(wav_path)
+        .arg("-af")
+        .arg("astats=metadata=1:reset=16000")
+        .arg("-f")
+        .arg("null")
+        .arg("-")
+        .output()
+        .await?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    tracing::trace!("ffmpeg astats output: {}", stderr);
+
+    if !output.status.success() && !stderr.contains("lavfi.astats") {
+        tracing::error!("ffmpeg astats failed: {}", stderr);
+        return Err("ffmpeg astats failed".into());
+    }
+
+    let peaks = parse_peaks(&stderr);
+
+    let duration = peaks.len() as f64;
+
+    tracing::info!(
+        "Extracted {} peak values (duration: {}s)",
+        peaks.len(),
+        duration
+    );
+
+    Ok(AudioPeaks { peaks, duration })
+}
+
+/// Parse `lavfi.astats.Overall.Peak_amplitude=<value>` lines from ffmpeg stderr.
+fn parse_peaks(stderr: &str) -> Vec<f64> {
+    stderr
+        .lines()
+        .filter_map(|line| {
+            let marker = "lavfi.astats.Overall.Peak_amplitude=";
+            let pos = line.find(marker)?;
+            let value_str = line[pos + marker.len()..].trim();
+            value_str.parse::<f64>().ok()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_peaks;
+
+    #[test]
+    fn test_parse_peaks_basic() {
+        let stderr = "\
+[Parsed_astats_0 @ 0x...] lavfi.astats.Overall.Peak_amplitude=0.123456\n\
+[Parsed_astats_0 @ 0x...] lavfi.astats.Overall.Peak_amplitude=0.654321\n\
+[Parsed_astats_0 @ 0x...] lavfi.astats.Overall.Peak_amplitude=0.000000\n";
+        let peaks = parse_peaks(stderr);
+        assert_eq!(peaks.len(), 3);
+        assert!((peaks[0] - 0.123_456).abs() < 1e-6);
+        assert!((peaks[1] - 0.654_321).abs() < 1e-6);
+        assert!((peaks[2]).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_parse_peaks_empty() {
+        let peaks = parse_peaks("no matching lines here\n");
+        assert!(peaks.is_empty());
+    }
+}

--- a/gt_ffmpeg/src/lib.rs
+++ b/gt_ffmpeg/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio_extraction;
+pub mod audio_peaks;
 pub mod edit;
 pub mod ffprobe;
 pub mod keyframes_extraction;

--- a/video_ingestor/src/main.rs
+++ b/video_ingestor/src/main.rs
@@ -24,6 +24,7 @@ struct Config {
     output_bucket: String,
     keyframes_prefix: String,
     audio_prefix: String,
+    peaks_prefix: String,
     transcode_prefix: String,
 
     dynamodb_table: String,
@@ -70,20 +71,34 @@ async fn main() {
     )
     .await;
 
-    // In parallel, do audio extraction to a temp file, extract keyframes, use ffprobe to get metadata
-    // Await the tasks to ensure they complete
+    // Extract audio to disk first so that the peaks task can read the same
+    // temp file concurrently with the S3 upload.
+    let audio_temp_file_path =
+        std::env::temp_dir().join("audiofile").to_str().unwrap()[..].to_string();
+
+    {
+        let audio_stdout =
+            audio_extraction::extract(&input_video_file_path, config.speech_track_number)
+                .expect("failed to extract audio");
+        save_stdio_to_file(audio_stdout, &audio_temp_file_path)
+            .await
+            .expect("failed to save audio to file");
+    }
+
+    // In parallel: upload audio to S3, extract keyframes, run ffprobe, detect
+    // silence, transcode to HLS, and compute audio peaks from the WAV.
     let (
         audio_result,
         keyframes_result,
         metadata_result,
         silence_result,
         transcode_result,
+        peaks_result,
     ) = tokio::join!(
-        do_audio_extraction_task(
+        upload_audio_to_s3(
             &aws_config,
-            config.speech_track_number,
             config.audio_prefix.clone(),
-            input_video_file_path.clone(),
+            audio_temp_file_path.clone(),
             config.output_bucket.clone(),
             input_key.clone()
         ),
@@ -107,15 +122,23 @@ async fn main() {
             input_video_file_path.clone(),
             config.output_bucket.clone(),
             input_key.clone()
-        )
+        ),
+        do_audio_peaks_task(
+            &aws_config,
+            config.peaks_prefix.clone(),
+            audio_temp_file_path.clone(),
+            config.output_bucket.clone(),
+            input_key.clone()
+        ),
     );
 
-    let audio_result = audio_result.expect("failed to extract audio");
+    let audio_result = audio_result.expect("failed to upload audio");
     let keyframes_result =
         keyframes_result.expect("failed to extract keyframes");
     let metadata_result = metadata_result.expect("failed to get metadata");
     let silence_result = silence_result.expect("failed to extract silence");
     let transcode_result = transcode_result.expect("failed to transcode");
+    let peaks_result = peaks_result.expect("failed to compute audio peaks");
 
     let results = IngestionResults {
         input_key,
@@ -124,6 +147,7 @@ async fn main() {
         keyframes: keyframes_result,
         silence: silence_result,
         transcode: transcode_result,
+        peaks: peaks_result,
     };
 
     // Insert the metadata into the DynamoDB table
@@ -254,7 +278,7 @@ async fn save_results_to_dynamodb(
         .table_name(table_name)
         .key("key", AttributeValue::S(results.input_key.clone()))
         .update_expression(
-            "SET metadata = :metadata, audio = :audio, keyframes = :keyframes, silence = :silence, transcode = :transcode",
+            "SET metadata = :metadata, audio = :audio, keyframes = :keyframes, silence = :silence, transcode = :transcode, peaks = :peaks",
         )
         .expression_attribute_values(":metadata", format_metadata(&results.metadata))
         .expression_attribute_values(":audio", AttributeValue::S(results.audio.to_string()))
@@ -324,6 +348,7 @@ async fn save_results_to_dynamodb(
                     .collect(),
             ),
         )
+        .expression_attribute_values(":peaks", AttributeValue::S(results.peaks))
         .send()
         .await?;
 
@@ -338,39 +363,28 @@ struct IngestionResults {
     keyframes: Vec<String>,
     silence: Vec<Segment>,
     transcode: Vec<HLSEntry>,
+    peaks: String,
 }
 
-fn do_audio_extraction_task(
+/// Upload the already-extracted WAV file to S3 and return the S3 key.
+fn upload_audio_to_s3(
     aws_config: &SdkConfig,
-    track_number: u32,
     audio_prefix: String,
-    temp_file_path: String,
+    audio_temp_file_path: String,
     output_bucket: String,
     input_key: String,
 ) -> tokio::task::JoinHandle<String> {
     let s3_client = aws_sdk_s3::Client::new(aws_config);
 
     tokio::spawn(async move {
-        // Extract audio from the video file
-        let audio_temp_file_path =
-            std::env::temp_dir().join("audiofile").to_str().unwrap()[..]
-                .to_string();
-        let audio = audio_extraction::extract(&temp_file_path, track_number)
-            .expect("failed to extract audio");
-
-        save_stdio_to_file(audio, &audio_temp_file_path)
-            .await
-            .expect("failed to save audio to file");
-
         let output_key = format!("{audio_prefix}/{input_key}");
 
-        // Upload the audio to an S3 bucket
         s3_client
             .put_object()
             .bucket(output_bucket)
             .key(output_key.as_str())
             .body(
-                ByteStream::from_path(audio_temp_file_path.clone())
+                ByteStream::from_path(audio_temp_file_path)
                     .await
                     .unwrap(),
             )
@@ -378,7 +392,7 @@ fn do_audio_extraction_task(
             .await
             .expect("failed to upload audio");
 
-        output_key.to_string()
+        output_key
     })
 }
 
@@ -542,5 +556,46 @@ fn do_transcode_task(
 
         // Return the S3 keys of the transcoded files
         transcode_keys
+    })
+}
+
+/// Compute per-second peak amplitudes from the WAV file, serialize to JSON,
+/// upload to S3, and return the S3 key.
+fn do_audio_peaks_task(
+    aws_config: &SdkConfig,
+    peaks_prefix: String,
+    audio_temp_file_path: String,
+    output_bucket: String,
+    input_key: String,
+) -> tokio::task::JoinHandle<String> {
+    let s3_client = aws_sdk_s3::Client::new(aws_config);
+
+    tokio::spawn(async move {
+        let audio_peaks = gt_ffmpeg::audio_peaks::extract(&audio_temp_file_path)
+            .await
+            .expect("failed to compute audio peaks");
+
+        let json = serde_json::json!({
+            "peaks": audio_peaks.peaks,
+            "duration": audio_peaks.duration,
+        });
+
+        let json_bytes = serde_json::to_vec(&json).expect("failed to serialize peaks");
+
+        let output_key = format!("{peaks_prefix}/{input_key}.json");
+
+        tracing::info!("Uploading audio peaks to {}", output_key);
+
+        s3_client
+            .put_object()
+            .bucket(output_bucket)
+            .key(&output_key)
+            .body(ByteStream::from(json_bytes))
+            .content_type("application/json")
+            .send()
+            .await
+            .expect("failed to upload audio peaks");
+
+        output_key
     })
 }

--- a/video_ingestor/src/main.rs
+++ b/video_ingestor/src/main.rs
@@ -73,9 +73,19 @@ async fn main() {
 
     // Extract audio to disk first so that the peaks task can read the same
     // temp file concurrently with the S3 upload.
-    let audio_temp_file_path =
-        std::env::temp_dir().join("audiofile").to_str().unwrap()[..].to_string();
+    let audio_temp_file_path = {
+        use std::time::{SystemTime, UNIX_EPOCH};
 
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before UNIX_EPOCH")
+            .as_millis();
+
+        std::env::temp_dir()
+            .join(format!("audiofile-{}-{}.wav", std::process::id(), ts))
+            .to_string_lossy()
+            .to_string()
+    };
     {
         let audio_stdout =
             audio_extraction::extract(&input_video_file_path, config.speech_track_number)


### PR DESCRIPTION
This pull request adds support for extracting and storing per-second audio peak amplitudes for ingested video clips. It introduces a new backfill tool to compute peaks for existing clips, updates the ingestion pipeline to compute and save peaks during ingestion, and enhances configuration and DynamoDB schema to include peaks information.

**Audio Peaks Extraction and Storage**

* Added a new Rust crate and binary `audio_peaks_backfill` for backfilling per-second audio peaks for already-ingested video clips. This tool reads WAV files from S3, computes peaks, uploads JSON results to S3, and updates DynamoDB records. [[1]](diffhunk://#diff-e05e883a717036cd9718de56931d1f5d970e8ea4016b207edff6aa59d428a9a0R1-R29) [[2]](diffhunk://#diff-faa6657a24f3300a9df8fb52cc4c0715e0f9fa80c9025e6ec77b1f42320bf8b0R1-R291) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R22)
* Implemented `audio_peaks` module in `gt_ffmpeg`, providing asynchronous extraction of per-second peak amplitudes from WAV files using ffmpeg, with tests and documentation. [[1]](diffhunk://#diff-6b4220d8591569a30ee8bbf99d31184849447fdb94c46f249bf0c2db2a9e6bcbR1-R150) [[2]](diffhunk://#diff-7d4139fec2abedf93cc6d8e2940320c49709bd0bec04b2c0a3ec94d2099cf946R2)

**Ingestion Pipeline Enhancements**

* Updated the main ingestion process in `video_ingestor` to extract audio peaks in parallel with other tasks, upload peaks JSON to S3, and store the S3 key in DynamoDB. This includes new config fields, result handling, and DynamoDB update logic. [[1]](diffhunk://#diff-307b6bac061ae60730052e074e9e979266bec5a6cd1db6c698056a8438786e59L73-R101) [[2]](diffhunk://#diff-307b6bac061ae60730052e074e9e979266bec5a6cd1db6c698056a8438786e59L110-R141) [[3]](diffhunk://#diff-307b6bac061ae60730052e074e9e979266bec5a6cd1db6c698056a8438786e59R150) [[4]](diffhunk://#diff-307b6bac061ae60730052e074e9e979266bec5a6cd1db6c698056a8438786e59L257-R281) [[5]](diffhunk://#diff-307b6bac061ae60730052e074e9e979266bec5a6cd1db6c698056a8438786e59R351) [[6]](diffhunk://#diff-307b6bac061ae60730052e074e9e979266bec5a6cd1db6c698056a8438786e59R366-R395) [[7]](diffhunk://#diff-307b6bac061ae60730052e074e9e979266bec5a6cd1db6c698056a8438786e59R561-R601) [[8]](diffhunk://#diff-307b6bac061ae60730052e074e9e979266bec5a6cd1db6c698056a8438786e59R27)

**Infrastructure and Configuration**

* Added `PEAKS_PREFIX` environment/config variable to both the ingestion pipeline and CDK construct, ensuring consistent S3 key structure for peaks JSON files. [[1]](diffhunk://#diff-68dc6e9208930877d0bfa76dbd8106c2f89532e2f8e89ab252c63363053ed5a8R87) [[2]](diffhunk://#diff-307b6bac061ae60730052e074e9e979266bec5a6cd1db6c698056a8438786e59R27)

These changes enable both real-time and backfill computation of per-second audio peaks, improving the richness of stored video metadata and supporting downstream features that rely on audio analysis.