### PR TITLE
Update version strings to 'v1.0.0' for steps for legacy case

### DIFF
--- a/video_ingestor/src/main.rs
+++ b/video_ingestor/src/main.rs
@@ -603,27 +603,27 @@ async fn get_stored_ingestion_versions(
             if legacy_version == LEGACY_GLOBAL_INGESTION_VERSION {
                 versions.insert(
                     STEP_AUDIO_UPLOAD.to_string(),
-                    STEP_VERSION_AUDIO_UPLOAD.to_string(),
+                    "v1.0.0",
                 );
                 versions.insert(
                     STEP_KEYFRAMES.to_string(),
-                    STEP_VERSION_KEYFRAMES.to_string(),
+                    "v1.0.0",
                 );
                 versions.insert(
                     STEP_METADATA.to_string(),
-                    STEP_VERSION_METADATA.to_string(),
+                    "v1.0.0",
                 );
                 versions.insert(
                     STEP_SILENCE.to_string(),
-                    STEP_VERSION_SILENCE.to_string(),
+                    "v1.0.0",
                 );
                 versions.insert(
                     STEP_TRANSCODE_HLS.to_string(),
-                    STEP_VERSION_TRANSCODE_HLS.to_string(),
+                    "v1.0.0",
                 );
                 versions.insert(
                     STEP_PEAKS.to_string(),
-                    STEP_VERSION_PEAKS.to_string(),
+                    "v1.0.0",
                 );
             }
         }

--- a/video_ingestor/src/main.rs
+++ b/video_ingestor/src/main.rs
@@ -603,27 +603,27 @@ async fn get_stored_ingestion_versions(
             if legacy_version == LEGACY_GLOBAL_INGESTION_VERSION {
                 versions.insert(
                     STEP_AUDIO_UPLOAD.to_string(),
-                    "v1.0.0",
+                    "v1.0.0".to_string(),
                 );
                 versions.insert(
                     STEP_KEYFRAMES.to_string(),
-                    "v1.0.0",
+                    "v1.0.0".to_string(),
                 );
                 versions.insert(
                     STEP_METADATA.to_string(),
-                    "v1.0.0",
+                    "v1.0.0".to_string(),
                 );
                 versions.insert(
                     STEP_SILENCE.to_string(),
-                    "v1.0.0",
+                    "v1.0.0".to_string(),
                 );
                 versions.insert(
                     STEP_TRANSCODE_HLS.to_string(),
-                    "v1.0.0",
+                    "v1.0.0".to_string(),
                 );
                 versions.insert(
                     STEP_PEAKS.to_string(),
-                    "v1.0.0",
+                    "v1.0.0".to_string(),
                 );
             }
         }


### PR DESCRIPTION
This pull request simplifies how ingestion step versions are set for legacy ingestion flows in the `get_stored_ingestion_versions` function. Instead of referencing separate version constants for each step, all legacy steps now use the hardcoded version `"v1.0.0"`. This corrects an issue where a legacy item was being treated as if it was already processed by all current ingestion processes.

**Legacy ingestion version handling:**
* Updated the logic in `get_stored_ingestion_versions` in `video_ingestor/src/main.rs` so that all legacy ingestion steps (`STEP_AUDIO_UPLOAD`, `STEP_KEYFRAMES`, `STEP_METADATA`, `STEP_SILENCE`, `STEP_TRANSCODE_HLS`, `STEP_PEAKS`) are assigned the version `"v1.0.0"` directly, replacing the use of individual step version constants.