### PR TITLE
fix(video_ingestor): initialize ingestion_versions map

### DIFF
--- a/video_ingestor/src/main.rs
+++ b/video_ingestor/src/main.rs
@@ -501,6 +501,17 @@ async fn save_results_to_dynamodb(
             .push((":peaks".to_string(), AttributeValue::S(peaks)));
     }
 
+    if !results.updated_versions.is_empty() {
+        update_expressions.push(
+            "ingestion_versions = if_not_exists(ingestion_versions, :empty_ingestion_versions)"
+                .to_string(),
+        );
+        expression_attribute_values.push((
+            ":empty_ingestion_versions".to_string(),
+            AttributeValue::M(HashMap::new()),
+        ));
+    }
+
     for (step, version) in results.updated_versions {
         let name_key = format!("#step_{}", step);
         let value_key = format!(":version_{}", step);

--- a/video_ingestor/src/main.rs
+++ b/video_ingestor/src/main.rs
@@ -502,14 +502,19 @@ async fn save_results_to_dynamodb(
     }
 
     if !results.updated_versions.is_empty() {
-        update_expressions.push(
-            "ingestion_versions = if_not_exists(ingestion_versions, :empty_ingestion_versions)"
-                .to_string(),
-        );
-        expression_attribute_values.push((
-            ":empty_ingestion_versions".to_string(),
-            AttributeValue::M(HashMap::new()),
-        ));
+        dynamodb_client
+            .update_item()
+            .table_name(table_name)
+            .key("key", AttributeValue::S(results.input_key.clone()))
+            .update_expression(
+                "SET ingestion_versions = if_not_exists(ingestion_versions, :empty_ingestion_versions)",
+            )
+            .expression_attribute_values(
+                ":empty_ingestion_versions",
+                AttributeValue::M(HashMap::new()),
+            )
+            .send()
+            .await?;
     }
 
     for (step, version) in results.updated_versions {


### PR DESCRIPTION
## What
- initialize `ingestion_versions` with `if_not_exists` before nested step updates
- keep existing per-step version writes unchanged

## Why
DynamoDB rejects nested updates when the parent map attribute does not exist, causing `ValidationException: The document path provided in the update expression is invalid for update`.

## Verification
- `cargo check -p video_ingestor`